### PR TITLE
Typo Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ cmaize_find_or_build_optional_dependency(
     VERSION 5e4f3475b5cb77414bca1f3dde7d6fd9cb4d2011
     BUILD_TARGET eigen
     FIND_TARGET Eigen3::Eigen
-    BUILD_ARGS EIGEN_BUILD_TESTING=OFF
+    CMAKE_ARGS EIGEN_BUILD_TESTING=OFF
 )
 
 ## Add libraries ##


### PR DESCRIPTION
Correct `BUILD_ARGS` to `CMAKE_ARGS` for `cmaize_find_or_build_optional_dependency` of Eigen.