### PR TITLE
Update Eigen dependency to find installed version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ include(cmake/cxx_api_docs.cmake)
 cmaize_find_or_build_optional_dependency(
     eigen
     ENABLE_EIGEN_SUPPORT
+    NAME Eigen3
     URL https://www.gitlab.com/libeigen/eigen
     VERSION 5e4f3475b5cb77414bca1f3dde7d6fd9cb4d2011
     BUILD_TARGET eigen


### PR DESCRIPTION
## Description

CMaize uses `find_package()` in Config search mode to detect an installed version of a dependency. `find_package` in this mode looks for files named `<PackageName>Config.cmake` (case sensitive) or `<lowercasePackageName>-config.cmake` (also case sensitive, but lowercase). CMaize, by default, uses the dependency name provided to `cmaize_find_or_build_dependency`, which is `eigen`, but the Eigen package generates this file as `Eigen3Config.cmake`.

## Solution

Use the optional `NAME` field in `cmaize_find_or_build_dependency` to set the correct `find_package` name to Eigen3.

Required for NWChemEx/TensorWrapper#212.

## TODOs

- [x] Verify that this solution works with an installed version of Eigen (through Spack for me).
- [x] Verify that this solution works when building Eigen from source on my system (Linux, GCC 14.2.1).