### PR TITLE
Remove Dependencies with Negated Contribution

### DIFF
--- a/include/sigma/detail_/setter.hpp
+++ b/include/sigma/detail_/setter.hpp
@@ -1,9 +1,9 @@
 #pragma once
 #include "sigma/uncertain.hpp"
 
-/** @file setter.hpp 
+/** @file setter.hpp
  *  @brief Defines the Setter class
- */ 
+ */
 
 namespace sigma::detail_ {
 
@@ -59,10 +59,15 @@ public:
      */
     void update_sd() {
         m_x_.m_sd_ = 0.0;
+        std::vector<dep_sd_ptr> zero_contributions{};
         for(const auto& [dep, deriv] : m_x_.m_deps_) {
-            if(deriv == 0.0) continue;
+            if(deriv == 0.0) {
+                zero_contributions.emplace_back(dep);
+                continue;
+            }
             m_x_.m_sd_ += std::pow(*dep.get() * deriv, 2.0);
         }
+        for(const auto& dep : zero_contributions) { m_x_.m_deps_.erase(dep); }
         m_x_.m_sd_ = std::sqrt(m_x_.m_sd_);
     }
 

--- a/tests/unit_tests/detail_/test_setter.cpp
+++ b/tests/unit_tests/detail_/test_setter.cpp
@@ -55,6 +55,6 @@ TEMPLATE_TEST_CASE("Setter", "", sigma::UFloat, sigma::UDouble) {
         test_uncertain(a, 3.0, 0.3, 1);
         // Explicitly update the standard deviation
         testing_a.update_sd();
-        test_uncertain(a, 3.0, 0.0, 1);
+        test_uncertain(a, 3.0, 0.0, 0);
     }
 }

--- a/tests/unit_tests/operations/test_arithmetic.cpp
+++ b/tests/unit_tests/operations/test_arithmetic.cpp
@@ -13,7 +13,7 @@ TEMPLATE_TEST_CASE("Arithmetic", "", sigma::UFloat, sigma::UDouble) {
     SECTION("Negation") {
         test_uncertain(-a, -1.0, 0.1, 1);
         test_uncertain(-(a + b), -3.0, 0.2236, 2);
-        test_uncertain(-a + a, 0.0, 0.0, 1);
+        test_uncertain(-a + a, 0.0, 0.0, 0);
     }
     SECTION("Addition") {
         SECTION("With Uncertain") { test_uncertain(a + b, 3.0, 0.2236, 2); }
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("Arithmetic", "", sigma::UFloat, sigma::UDouble) {
     SECTION("Subtraction") {
         SECTION("With Uncertain") {
             test_uncertain(a - b, -1.0, 0.2236, 2);
-            test_uncertain(a - a, 0.0, 0.0, 1);
+            test_uncertain(a - a, 0.0, 0.0, 0);
         }
         SECTION("With Certain") {
             test_uncertain(a - 1.0, 0.0, 0.1, 1);
@@ -90,7 +90,7 @@ TEMPLATE_TEST_CASE("Arithmetic", "", sigma::UFloat, sigma::UDouble) {
     SECTION("Division") {
         SECTION("By Uncertain") {
             test_uncertain(a / b, 0.5, 0.0707, 2);
-            test_uncertain(a / a, 1.0, 0.0, 1);
+            test_uncertain(a / a, 1.0, 0.0, 0);
         }
         SECTION("By Certain") {
             int two = 2;
@@ -107,7 +107,7 @@ TEMPLATE_TEST_CASE("Arithmetic", "", sigma::UFloat, sigma::UDouble) {
             x /= b;
             y /= a;
             test_uncertain(x, 0.5, 0.0707, 2);
-            test_uncertain(y, 1.0, 0.0, 1);
+            test_uncertain(y, 1.0, 0.0, 0);
         }
         SECTION("By Certain") {
             int two = 2;

--- a/tests/unit_tests/operations/test_basic.cpp
+++ b/tests/unit_tests/operations/test_basic.cpp
@@ -16,7 +16,7 @@ TEMPLATE_TEST_CASE("Basic", "", sigma::UFloat, sigma::UDouble) {
         REQUIRE(-a == sigma::copysign(a, -b));
         REQUIRE(-a == sigma::copysign(a, -1.0));
         REQUIRE(-1.0 == sigma::copysign(1.0, -b));
-        test_uncertain(a + sigma::copysign(a, -1.0), 0.0, 0.0, 1);
+        test_uncertain(a + sigma::copysign(a, -1.0), 0.0, 0.0, 0);
     }
     SECTION("Absolute Value") { 
         REQUIRE(a == sigma::abs(-a));

--- a/tests/unit_tests/operations/test_error_and_gamma.cpp
+++ b/tests/unit_tests/operations/test_error_and_gamma.cpp
@@ -13,7 +13,7 @@ TEMPLATE_TEST_CASE("Error Function and Gamma", "", sigma::UFloat,
     }
     SECTION("Complementary Error Function") {
         test_uncertain(sigma::erfc(a), 0.1573, 0.0415, 1);
-        test_uncertain(sigma::erf(a) + sigma::erfc(a), 1.0, 0.0, 1);
+        test_uncertain(sigma::erf(a) + sigma::erfc(a), 1.0, 0.0, 0);
     }
     SECTION("Gamma Function") {
         test_uncertain(sigma::tgamma(a), 1.0, 0.0577, 1);

--- a/tests/unit_tests/operations/test_exponents.cpp
+++ b/tests/unit_tests/operations/test_exponents.cpp
@@ -17,10 +17,10 @@ TEMPLATE_TEST_CASE("Exponents", "", sigma::UFloat, sigma::UDouble) {
             test_uncertain(sigma::pow(a, 2), 1.0, 0.2, 1);
             test_uncertain(sigma::pow((a + b), -1), 0.3333, 0.0248, 2);
             test_uncertain(sigma::pow((a + b + a * b), 0.5), 2.2361, 0.1118, 2);
-            test_uncertain(sigma::pow((a + b + a * b), 0.0), 1.0, 0.0, 2);
+            test_uncertain(sigma::pow((a + b + a * b), 0.0), 1.0, 0.0, 0);
         }
         SECTION("Uncertain exponent") {
-            test_uncertain(sigma::pow(a, b), 1.0, 0.2, 2);
+            test_uncertain(sigma::pow(a, b), 1.0, 0.2, 1);
             test_uncertain(sigma::pow(c, -b), 0.0625, 0.0214, 2);
             test_uncertain(sigma::pow(c, a * 0.5), 2.0, 0.1709, 2);
         }


### PR DESCRIPTION
Currently, error sources whose contributions have become completely negated (i.e. equal to zero) are kept in the `Uncertain` values dependency map. In cases where multiple dependencies are introduced and then negated, this behavior could lead to bloated dependency lists filled with non-contributing error sources. The changes in this PR alter the `Setter::update_sd` method so that it removes those dependencies whose contributions have been completely negated.