### PR TITLE
Fix BUILD_TESTING getting undefined when set to OFF

### DIFF
--- a/cmake/get_cmaize.cmake
+++ b/cmake/get_cmaize.cmake
@@ -5,9 +5,7 @@ function(get_cmaize)
     endif()
 
     # Store whether we are building tests or not, then turn off the tests
-    if(BUILD_TESTING)
-        set(build_testing_old "${BUILD_TESTING}")
-    endif()
+    set(build_testing_old "${BUILD_TESTING}")
     set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 
     # Download CMakePP and bring it into scope
@@ -21,7 +19,7 @@ function(get_cmaize)
 
     # Restore the previous value, if set
     # Unset otherwise
-    if(build_testing_old)
+    if(NOT "${build_testing_old}" STREQUAL "")
         set(BUILD_TESTING "${build_testing_old}" CACHE BOOL "" FORCE)
     else()
         unset(BUILD_TESTING CACHE)


### PR DESCRIPTION
The title says it all pretty much. The implementation of `cmake/get_cmaize.cmake` used here was unsetting `BUILD_TESTING` when `BUILD_TESTING = OFF`, causing very hard to track down problems in dependent packages. This PR solves the issue by partially pulling in the current implementation at [NWChemEx/NWXCMake/cmake/get_cmaize.cmake](https://github.com/NWChemEx/NWXCMake/blob/master/cmake/get_cmaize.cmake). I actually think that the unsetting logic at the bottom potentially should be brought into the NWChemEx/NWXCMake implementation, too, but am not going to worry about it right now.