### PR TITLE
Better Derivative Updating

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   # Deploy Documentation
   deploy_dox:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -16,7 +16,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ssciwr/doxygen-install@v1
-      - uses: seanmiddleditch/gha-setup-ninja@v5
       - name: Build Doxygen Part
         run: |
           cmake -Bbuild -H. -GNinja -DONLY_BUILD_DOCS=ON -DDOCS_FAIL_ON_WARNING=ON

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,9 +11,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-15]
-        compiler: [gnu-13, gnu-14, clang-default]
+        compiler: [gnu-13, gnu-14]
         eigen: [ON]
         include:
+          - os: ubuntu-22.04
+            compiler: clang-default
+            eigen: ON
+          - os: macos-14
+            compiler: clang-default
+            eigen: ON
           - os: ubuntu-24.04
             compiler: gnu-12
             eigen: ON

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,7 +17,7 @@ jobs:
           - os: ubuntu-22.04
             compiler: clang-default
             eigen: ON
-          - os: macos-14
+          - os: macos-15
             compiler: clang-default
             eigen: ON
           - os: ubuntu-24.04

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: ssciwr/doxygen-install@v1
+      - uses: ssciwr/doxygen-install@v2
       - name: Build and Test
         run: |
           toolchain=${PWD}/.github/workflow_toolchains/${{matrix.compiler}}.cmake

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -10,16 +10,10 @@ jobs:
   test_library_unix:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14]
-        compiler: [gnu-13, gnu-14]
+        os: [ubuntu-24.04, macos-15]
+        compiler: [gnu-13, gnu-14, clang-default]
         eigen: [ON]
         include:
-          - os: ubuntu-22.04
-            compiler: clang-default
-            eigen: ON
-          - os: macos-14
-            compiler: clang-default
-            eigen: ON
           - os: ubuntu-24.04
             compiler: gnu-12
             eigen: ON
@@ -48,7 +42,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: ssciwr/doxygen-install@v1
+      - uses: ssciwr/doxygen-install@v2
       - name: Build and Test
         run: |
           SET "toolchain=%cd%\.github\workflow_toolchains\windows.cmake"

--- a/include/sigma/detail_/operation_common.hpp
+++ b/include/sigma/detail_/operation_common.hpp
@@ -63,7 +63,7 @@ void inplace_binary(Uncertain<T>& c, const Uncertain<T>& b, T mean, T dcda,
                     T dcdb) {
     detail_::Setter<Uncertain<T>> c_setter(c);
     c_setter.update_mean(mean);
-    c_setter.update_derivatives(dcda, false);
+    c_setter.update_derivatives(dcda);
     c_setter.update_derivatives(b.deps(), dcdb);
 }
 

--- a/include/sigma/detail_/setter.hpp
+++ b/include/sigma/detail_/setter.hpp
@@ -53,42 +53,30 @@ public:
      */
     void update_mean(value_t mean) { m_x_.m_mean_ = mean; }
 
-    /** @brief Calculate the standatd deviation of m_x_ based on the
-     *         uncertainty of its dependencies.
-     *
-     *  @throw none No throw guarantee
-     */
-    void update_sd() {
-        m_x_.m_sd_ = 0.0;
-        std::vector<dep_sd_ptr> zero_contributions{};
-        for(const auto& [dep, deriv] : m_x_.m_deps_) {
-            if(deriv == 0.0) {
-                zero_contributions.emplace_back(dep);
-                continue;
-            }
-            m_x_.m_sd_ += std::pow(*dep.get() * deriv, 2.0);
-        }
-        for(const auto& dep : zero_contributions) { m_x_.m_deps_.erase(dep); }
-        m_x_.m_sd_ = std::sqrt(m_x_.m_sd_);
-    }
-
     /** @brief Update of existing derivatives
      *
      *  @param dxda The partial derivative of the variable
-     *  @param call_update_std Whether or not to update the standard deviation
-     *                         after updating the dependencies. Primarily for
-     *                         minimizing repetitive work when multiple updates
-     *                         will be performed
      *
      *  @throw none No throw guarantee
      */
-    void update_derivatives(value_t dxda, bool call_update_std = true) {
-        if(dxda != 1.0) {
-            for(const auto& [dep, deriv] : m_x_.m_deps_) {
-                m_x_.m_deps_[dep] *= dxda;
-            }
+    void update_derivatives(value_t dxda) {
+        // If the derivative is one, we don't need to do anything since the
+        // derivatives are unchanged
+        if(dxda == 1.0) return;
+        // If the derivative is zero, we can just clear the dependencies and set
+        // the standard deviation to zero
+        if(dxda == 0.0) {
+            m_x_.m_deps_.clear();
+            m_x_.m_sd_ = 0.0;
+            return;
         }
-        if(call_update_std) update_sd();
+        // Update the derivatives in place
+        for(const auto& [dep, deriv] : m_x_.m_deps_) {
+            m_x_.m_deps_[dep] *= dxda;
+        }
+        // If the derivative is not negative one, we need to update the
+        // standard deviation as well.
+        if(dxda != -1.0) { m_x_.m_sd_ *= std::abs(dxda); }
     }
 
     /** @brief Update/addition of derivatives
@@ -96,24 +84,74 @@ public:
      *  @param deps The dependencies to update
      *  @param dxda The partial derivative of this variable with respect to
      *              the dependency
-     *  @param call_update_std Whether or not to update the standard deviation
-     *                         after updating the dependencies. Primarily for
-     *                         minimizing repetitive work when multiple updates
-     *                         will be performed
      *
      *  @throw none No throw guarantee
      */
-    void update_derivatives(const deps_map_t& deps, value_t dxda,
-                            bool call_update_std = true) {
+    void update_derivatives(const deps_map_t& deps, value_t dxda) {
+        // If the derivative is zero, we can skip the update since it won't
+        // change anything
+        if(dxda == 0.0) { return; }
+
+        // We need to determine which dependencies are new, which are zeroed
+        // out, and which are updated. We can then update the standard deviation
+        // accordingly.
+        std::vector<dep_sd_ptr> zero_contributions{};
+        std::vector<dep_sd_ptr> new_contributions{};
+        std::vector<dep_sd_ptr> updated_contributions{};
         for(const auto& [dep, deriv] : deps) {
-            auto new_deriv = dxda * deriv;
-            if(m_x_.m_deps_.count(dep) != 0) {
-                m_x_.m_deps_[dep] += new_deriv;
+            if(m_x_.m_deps_.count(dep) == 0) {
+                new_contributions.push_back(dep);
             } else {
-                m_x_.m_deps_.emplace(std::make_pair(std::move(dep), new_deriv));
+                if(m_x_.m_deps_[dep] + (dxda * deriv) == 0.0) {
+                    zero_contributions.push_back(dep);
+                } else {
+                    updated_contributions.push_back(dep);
+                }
             }
         }
-        if(call_update_std) update_sd();
+
+        // If more than half of the existing dependencies are being updated,
+        // it's more efficient to update the derivatives and then recalculate
+        // the standard deviation from scratch. Otherwise, we can update the
+        // standard deviation in place by removing the contribution of the
+        // zeroed and updated dependencies and then adding the new contribution
+        // of the updated dependencies.
+        if(updated_contributions.size() > (m_x_.m_deps_.size() / 2)) {
+            for(const auto& dep : zero_contributions) {
+                m_x_.m_deps_.erase(dep);
+            }
+            for(const auto& dep : updated_contributions) {
+                m_x_.m_deps_[dep] += dxda * deps.at(dep);
+            }
+            m_x_.m_sd_ = 0.0;
+            for(const auto& [dep, deriv] : m_x_.m_deps_) {
+                m_x_.m_sd_ += std::pow(*dep.get() * deriv, 2.0);
+            }
+        } else {
+            m_x_.m_sd_ = std::pow(m_x_.m_sd_, 2.0);
+            for(const auto& dep : zero_contributions) {
+                m_x_.m_sd_ -= std::pow(*dep.get() * m_x_.m_deps_[dep], 2.0);
+                m_x_.m_deps_.erase(dep);
+            }
+            // While removing the contribution of the zeroed dependencies, we
+            // can get minor numerical variations that cause the standard
+            // deviation to become small and negative if the variable is now
+            // independent of all other variables. In this case, we can just set
+            // it to zero.
+            if(m_x_.m_deps_.size() == 0) { m_x_.m_sd_ = 0.0; }
+            for(const auto& dep : updated_contributions) {
+                m_x_.m_sd_ -= std::pow(*dep.get() * m_x_.m_deps_[dep], 2.0);
+                m_x_.m_deps_[dep] += dxda * deps.at(dep);
+                m_x_.m_sd_ += std::pow(*dep.get() * m_x_.m_deps_[dep], 2.0);
+            }
+        }
+        // Finally, we need to add the contributions of the new dependencies to
+        // the standard deviation and take the square root.
+        for(const auto& dep : new_contributions) {
+            m_x_.m_deps_.emplace(std::make_pair(dep, dxda * deps.at(dep)));
+            m_x_.m_sd_ += std::pow(*dep.get() * m_x_.m_deps_[dep], 2.0);
+        }
+        m_x_.m_sd_ = std::sqrt(m_x_.m_sd_);
     }
 
 private:

--- a/tests/unit_tests/detail_/test_setter.cpp
+++ b/tests/unit_tests/detail_/test_setter.cpp
@@ -19,21 +19,22 @@ TEMPLATE_TEST_CASE("Setter", "", sigma::UFloat, sigma::UDouble) {
     }
     SECTION("Update the derivatives") {
         SECTION("Only existing derivatives") {
-            // Don't update the first time, making sure that the flag works
-            testing_a.update_derivatives(2.0, false);
-            test_uncertain(a, 3.0, 0.3, 1);
-            // Should be the same update_derivative(4.0)
             testing_a.update_derivatives(2.0);
-            test_uncertain(a, 3.0, 1.2, 1);
+            test_uncertain(a, 3.0, 0.6, 1);
         }
         SECTION("One list of derivatives") {
-            SECTION("Only pre-existing entries in map") {
-                // Don't update the first time, making sure that the flag works
-                testing_a.update_derivatives(a.deps(), 1.0, false);
+            SECTION("Derivative of Zero") {
+                testing_a.update_derivatives(a.deps(), 0.0);
+                testing_a.update_derivatives(b.deps(), 0.0);
                 test_uncertain(a, 3.0, 0.3, 1);
-                // Check for changes across both calls
+            }
+            SECTION("Only pre-existing entries in map") {
                 testing_a.update_derivatives(a.deps(), 1.0);
-                test_uncertain(a, 3.0, 1.2, 1);
+                test_uncertain(a, 3.0, 0.6, 1);
+            }
+            SECTION("Pre-existing reduced to zero") {
+                testing_a.update_derivatives(a.deps(), -1.0);
+                test_uncertain(a, 3.0, 0.0, 0);
             }
             SECTION("Only new entries in map") {
                 testing_a.update_derivatives(b.deps(), 1.0);
@@ -48,13 +49,5 @@ TEMPLATE_TEST_CASE("Setter", "", sigma::UFloat, sigma::UDouble) {
                 test_uncertain(a, 3.0, 1.3, 2);
             }
         }
-    }
-    SECTION("Update the standard deviation") {
-        // Change derivatives without updating the standard deviation
-        testing_a.update_derivatives(0.0, false);
-        test_uncertain(a, 3.0, 0.3, 1);
-        // Explicitly update the standard deviation
-        testing_a.update_sd();
-        test_uncertain(a, 3.0, 0.0, 0);
     }
 }


### PR DESCRIPTION
Optimizations for the `Setter::update_derivative()` functions and removal of `Setter::update_sd()`. The `update_derivative()` version that scales all pre-existing contributions by a new partial derivative now handles a few special cases and then simply updates the derivative values and scales the standard deviation appropriately. The version that additively updates the contributions now screens the different sources as new, zeroed out, or updated. Depending on the number of updated sources, the standard deviation is either recalculated from scratch or update in place.