### PR TITLE
Adds open and closed intervals

### DIFF
--- a/include/sigma/interval.hpp
+++ b/include/sigma/interval.hpp
@@ -768,8 +768,12 @@ using IDouble = Interval<double>;
 } // namespace sigma
 
 namespace std {
+
+/// Specializes std::has for Intervals
 template<typename ValueType>
 struct hash<sigma::Interval<ValueType>> {
+    /// Hashes the lower and upper bounds of an interval and then combines them
+    /// using a simple XOR operation.
     size_t operator()(const sigma::Interval<ValueType>& i) const {
         std::size_t hash_low  = std::hash<ValueType>()(i.lower());
         std::size_t hash_high = std::hash<ValueType>()(i.upper());

--- a/include/sigma/interval.hpp
+++ b/include/sigma/interval.hpp
@@ -1,8 +1,9 @@
 #pragma once
+#include <algorithm>
 #include <boost/numeric/interval.hpp>
 #include <iostream>
+#include <optional>
 #include <type_traits>
-
 /** @file interval.hpp
  *  @brief Defines the Interval class
  */
@@ -25,11 +26,11 @@ public:
 
     /** @brief Default constructor
      *
-     *  Constructs an interval with both bounds set to 0.0.
+     *  Constructs an empty interval (contains no values).
      *
      *  @throw none No throw guarantee
      */
-    Interval() : m_interval_(0.0, 0.0) {}
+    Interval() {}
 
     /** @brief Construct an interval from a single value
      *
@@ -39,70 +40,287 @@ public:
      *
      *  @throw none No throw guarantee
      */
-    Interval(value_t value) : m_interval_(value, value) {}
+    Interval(value_t value) : Interval(value, value, false, false) {}
 
-    /** @brief Construct an interval from lower and upper bounds
+    /** @brief Construct an interval from two bounds
+     *
+     *  For convenience, the bounds are sorted so that lower() <= upper().
+     *
      *
      *  @param lower The lower bound of the interval
      *  @param upper The upper bound of the interval
-     *
+     *  @param left_open Is @p lower just outside the interval?
+     *  @param right_open Is @p upper just outside the interval?
      *  @throw none No throw guarantee
      */
-    Interval(value_t lower, value_t upper) : m_interval_(lower, upper) {}
+    Interval(value_t lower, value_t upper, bool left_open = false,
+             bool right_open = false) :
+      m_is_left_open_(left_open),
+      m_is_right_open_(right_open),
+      m_interval_(interval_t(std::min(lower, upper), std::max(lower, upper))) {
+        // A single value in an open interval is actually empty
+        if((left_open || right_open) && lower == upper) *this = Interval();
+    }
 
-    /** @brief Returns the lower bound of the interval
+    /** @brief Returns the distance between the interval's bounds.
      *
-     *  @return The lower bound value
+     *  The width of an interval is defined by |upper() - lower()|. The width
+     *  does NOT depend on the openness of the interval. The width of an empty
+     *  interval is undefined (and calling this member on an empty interval
+     * will cause a domain_error to be thrown)
      *
-     *  @throw none No throw guarantee
+     *  @return The width of the interval
+     *
+     *  @throw std::domain_error if the interval is empty
      */
-    value_t lower() const { return m_interval_.lower(); }
-
-    /** @brief Returns the upper bound of the interval
-     *
-     *  @return The upper bound value
-     *
-     *  @throw none No throw guarantee
-     */
-    value_t upper() const { return m_interval_.upper(); }
-
-    /** @brief Whether a scalar lies in this interval (endpoints included)
-     *
-     *  Returns true if lower() <= @p value <= upper(). Boundary values are
-     *  considered contained.
-     *
-     *  @param value The scalar to test
-     *
-     *  @return True if @p value lies in the closed interval from lower() to
-     *          upper()
-     *
-     *  @throw none No throw guarantee
-     */
-    bool contains(value_t value) const {
-        return value >= lower() && value <= upper();
+    value_t width() const {
+        assert_not_empty_();
+        return boost::numeric::width(*m_interval_);
     }
 
     /** @brief Returns the midpoint of the interval
      *
      *  @return The midpoint value
      *
-     *  @throw none No throw guarantee
+     *  @throw std::domain_error if the interval is empty
      */
-    value_t median() const { return boost::numeric::median(m_interval_); }
+    value_t median() const {
+        assert_not_empty_();
+        return boost::numeric::median(*m_interval_);
+    }
 
     /** @brief Returns the half-width of the interval
      *
-     *  This is the distance from the median to either endpoint.
+     *  This is the distance from the median to either endpoint. This is a
+     *  convenience method for width() / value_t{2}
      *
      *  @return The half-width value
      *
+     *  @throw std::domain_error if the interval is empty
+     */
+    value_t radius() const { return width() / value_t{2}; }
+
+    /** @brief Is *this the empty interval?
+     *
+     *  The empty interval contains no values.
+     *
+     *  @return True if *this is the empty interval, false otherwise.
+     *
      *  @throw none No throw guarantee
      */
-    value_t radius() const {
-        return boost::numeric::width(m_interval_) / value_t{2};
+    bool empty() const { return !m_interval_; }
+
+    /** @brief  Is lower() NOT contained in the interval?
+     *
+     *  @return True if lower() is NOT contained in the interval
+     *
+     *  @throw none No throw guarantee
+     */
+    bool left_open() const { return m_is_left_open_; }
+
+    /** @brief  Is lower() contained in the interval?
+     *
+     * @return True if lower() is contained in the interval.
+     *
+     * @throw none No throw guarantee.
+     */
+    bool left_closed() const { return !left_open(); }
+
+    /** @brief Is upper() NOT contained in the interval?
+     *
+     *  @return True if upper() is NOT contained in the interval
+     *
+     *  @throw none No throw guarantee
+     */
+    bool right_open() const { return m_is_right_open_; }
+
+    /** @brief Is upeer contained in the interval?
+     *
+     *  @return True if upper() is contained in the interval.
+     *
+     *  @throw none No throw guarantee
+     */
+    bool right_closed() const { return !right_open(); }
+
+    /** @brief Returns the lower bound of the interval
+     *
+     *  @return The lower bound value
+     *
+     *  @throw std::domain_error if the interval is empty
+     */
+    value_t lower() const {
+        assert_not_empty_();
+        return m_interval_->lower();
+    }
+
+    /** @brief Returns the upper bound of the interval
+     *
+     *  @return The upper bound value
+     *
+     *  @throw std::domain_error if the interval is empty
+     */
+    value_t upper() const {
+        assert_not_empty_();
+        return m_interval_->upper();
+    }
+
+    /** @brief Whether a scalar lies in this interval
+     *
+     *  Returns true if lower() <= @p value <= upper(). Equality to lower()/
+     *  upper() is only allowed if lower_closed()/upper_closed() is true,
+     *  respectively.
+     *
+     *  @param value The scalar to test
+     *
+     *  @return True if @p value lies in the interval represented by *this and
+     *          false otherwise.
+     *
+     *  @throw none No throw guarantee
+     */
+    bool contains(value_t value) const {
+        if(empty()) { return false; }
+
+        // Check if the value is definitely outside the interval
+        if(value < lower() || value > upper()) { return false; }
+
+        // Now we know it's squarely in the interval (or one of the bounds)
+
+        // Not allowed to be a bound if the interval is open on that side
+        if(left_open() && value == lower()) { return false; }
+        if(right_open() && value == upper()) { return false; }
+
+        return true;
+    }
+
+    /** @brief Is @p other fully contained in this interval?
+     *
+     */
+    bool contains(const Interval& other) const {
+        if(other.empty()) { return true; }
+        if(empty()) { return false; }
+
+        // Check if definitely outside the interval
+        if(other.lower() < lower() || other.upper() > upper()) { return false; }
+
+        // Check if the interval is squarely inside the interval
+        if(other.lower() > lower() && other.upper() < upper()) { return true; }
+
+        // *this and other must share at least one bound
+        // For each bound the choices are:
+        // *this open and other closed -> not okay
+        // *this open and other open -> okay
+        // *this closed and other closed -> okay
+        // *this closed and other open -> okay
+        if(other.lower() == lower()) {
+            if(left_open() && other.left_closed()) { return false; }
+        }
+        if(other.upper() == upper()) {
+            if(right_open() && other.right_closed()) { return false; }
+        }
+        return true;
+    }
+
+    /** @brief Returns the union of this interval and another interval
+     *
+     *  The union of two intervals is the smallest interval that contains both
+     *  intervals. Because the result must be an interval, union is only defined
+     *  when then the intervals overlap at least at one point.
+     *
+     *  @param other The interval to union with
+     *  @return The union of this interval and @p other
+     *
+     *  @throw std::domain_error if the intervals do not overlap. Strong throw
+     *          guarantee.
+     */
+    Interval set_union(const Interval& other) const {
+        if(empty()) { return other; }
+        if(other.empty()) { return *this; }
+        if(set_intersection(other).empty()) {
+            throw std::domain_error("Intervals do not overlap");
+        }
+        value_t low        = lower();
+        value_t hi         = upper();
+        bool lower_is_open = false;
+        bool upper_is_open = false;
+        if(lower() < other.lower()) { // *this has the lower bound
+            lower_is_open = left_open();
+        } else if(lower() == other.lower()) {
+            // If both are open, then result is open; otherwise closed
+            lower_is_open = left_open() && other.left_open();
+        } else {
+            low           = other.lower();
+            lower_is_open = other.left_open();
+        }
+
+        if(upper() > other.upper()) {
+            upper_is_open = right_open();
+        } else if(upper() == other.upper()) {
+            upper_is_open = right_open() && other.right_open();
+        } else {
+            hi            = other.upper();
+            upper_is_open = other.right_open();
+        }
+
+        return Interval(low, hi, lower_is_open, upper_is_open);
+    }
+
+    /** @brief Returns the intersection of this interval and another interval
+     *
+     *  The intersection of two intervals is the largest interval that is
+     *  contained in both intervals.
+     *
+     *  @param other The interval to intersect with
+     *  @return The intersection of this interval and @p other
+
+     *  @throw None No throw guarantee.
+     */
+    Interval set_intersection(const Interval& other) const {
+        if(empty() || other.empty()) { return Interval(); }
+        if(other.upper() < lower() || other.lower() > upper()) {
+            return Interval();
+        }
+        value_t low        = lower();
+        value_t hi         = upper();
+        bool lower_is_open = left_open();
+        bool upper_is_open = right_open();
+
+        if(lower() < other.lower()) {
+            low           = other.lower();
+            lower_is_open = other.left_open();
+        } else if(lower() > other.lower()) {
+            low           = lower();
+            lower_is_open = left_open();
+        } else {
+            lower_is_open = left_open() || other.left_open();
+        }
+
+        if(upper() > other.upper()) {
+            hi            = other.upper();
+            upper_is_open = other.right_open();
+        } else if(upper() < other.upper()) {
+            hi            = upper();
+            upper_is_open = right_open();
+        } else {
+            upper_is_open = right_open() || other.right_open();
+        }
+        return Interval(low, hi, lower_is_open, upper_is_open);
     }
 
     // -- Arithmetic in-place operators ----------------------------------------
+
+    /** @brief Negation of an interval
+     *
+     *  Given the interval [a, b], the negation is [-b, -a]. The openness of the
+     *  bounds is reversed, e.g., [a, b) becomes (-b, -a].
+     *
+     *  @return A new interval with negated bounds
+     *
+     *  @throw none No throw guarantee
+     */
+    Interval operator-() const {
+        if(empty()) { return Interval(); }
+        return Interval(-upper(), -lower(), right_open(), left_open());
+    }
 
     /** @brief In-place addition of another interval
      *
@@ -112,7 +330,15 @@ public:
      *  @throw none No throw guarantee
      */
     Interval& operator+=(const Interval& rhs) {
-        m_interval_ += rhs.m_interval_;
+        if(empty()) {
+            return *this = rhs;
+        } else if(rhs.empty()) {
+            return *this;
+        } else {
+            m_interval_      = *m_interval_ + *rhs.m_interval_;
+            m_is_left_open_  = left_open() || rhs.left_open();
+            m_is_right_open_ = right_open() || rhs.right_open();
+        }
         return *this;
     }
 
@@ -123,10 +349,7 @@ public:
      *
      *  @throw none No throw guarantee
      */
-    Interval& operator+=(value_t rhs) {
-        m_interval_ += rhs;
-        return *this;
-    }
+    Interval& operator+=(value_t rhs) { return *this += Interval(rhs, rhs); }
 
     /** @brief In-place subtraction of another interval
      *
@@ -135,10 +358,7 @@ public:
      *
      *  @throw none No throw guarantee
      */
-    Interval& operator-=(const Interval& rhs) {
-        m_interval_ -= rhs.m_interval_;
-        return *this;
-    }
+    Interval& operator-=(const Interval& rhs) { return *this += -rhs; }
 
     /** @brief In-place subtraction of a scalar
      *
@@ -147,10 +367,7 @@ public:
      *
      *  @throw none No throw guarantee
      */
-    Interval& operator-=(value_t rhs) {
-        m_interval_ -= rhs;
-        return *this;
-    }
+    Interval& operator-=(value_t rhs) { return *this -= Interval(rhs, rhs); }
 
     /** @brief In-place multiplication by another interval
      *
@@ -160,8 +377,133 @@ public:
      *  @throw none No throw guarantee
      */
     Interval& operator*=(const Interval& rhs) {
-        m_interval_ *= rhs.m_interval_;
-        return *this;
+        /* Putting this here in case it's helpful for optimizing.
+         * Given two intervals X = [a, b] and Y = [c, d], the product X * Y is:
+         * [min(ac, ad, bc, bd), max(ac, ad, bc, bd)]. Thus the entire product
+         * is determined by four sub-products: ac, ad, bc, and bd. Simple
+         * combinatorics suggests that there are 16 possible products for X*Y,
+         * (i.e., chose one sub-product for the new lower bound and one for the
+         * new upper bound).
+         *
+         * If we know that a < b and c < d, i.e., our intervals are not points,
+         * we can immediately rule out eight products:
+         *
+         * - [ac, ac], [ad, ad], [bc, bc], and [bd,bd].
+         * - [ac, ad], [ac, bc], [bd, bc], and [bd,ad].
+         *
+         * Proofs that these products are impossible are given below.
+         *
+         * To prove the first four products are impossible consider [ac, ac],
+         * which implies:
+         *
+         * - ac <= ad <= ac,
+         * - ac <= bc <= ac, and
+         * -ac <= bd <= ac
+         *
+         * The first inequality means c == d, the second means a == b. Which
+         * means X = [a, a] and Y = [c, c], i.e. X and Y must be points. This
+         * contridicts our assumption that X and Y are not points and thus these
+         * four products will never appear. Similar logic holds for the other
+         * three products of the form [xy, xy].
+         *
+         * Now consider the product [ac, ad]. This implies:
+         *
+         * - ac <= bc <= ad, and
+         * - ac <= bd <= ad
+         *
+         * If a is negative, then d <= bc/a <= c, which is not possible with the
+         * assumption c < d. If a is zero, the product [ac, ad] is [0, 0], which
+         * means bc and bd must be zero. b can't be zero because then
+         * X = [0, 0]. This would then mean that both c and d must be zero, but
+         * c and d both can't be zero because then Y = [0, 0]. Thus a must be
+         * positive. If a is positive, then so is b. If c >= 0 then d is
+         * positive and then we have that bd > ad, which is not consistent with
+         * bd <= ad. c also can't be negative because then bc < ac. We thus
+         * conclude that [ac, ad] is not possible.
+         *
+         * The remaining three proofs follow similarly. Let "target interval"
+         * refer to the interval we are proving is not possible. Then the proof
+         * proceeds by showing:
+         *
+         * - We get two inequalities by forcing the remaining two sub-products
+         *   to be bounded by the target interval. Above this showed that bc and
+         *   bd must be in the interval [ac, ad]. We term these the "implicit
+         *   sub-products" because they do not show up explicitly in the target
+         *   interval.
+         * - One of X or Y's bounds will appear twice in the target interval. We
+         *   term this the "common bound". Above this bound was "a".
+         * - If the common bound is the lower bound of X(Y) try assuming the
+         *   commonbound is negative and dividing the inequalities by it. If the
+         *   common bound is the upper bound, instead divide the inequalities by
+         *   the positive of it. This will cause one of the two inequalities to
+         *   be a contradiction eliminating that possibility. Above this ruled
+         *   out "a" being negative.
+         * - The common bound can't be zero otherwise X and Y collapse to
+         *   point intervals.
+         * - This means the common bound must be positive (negative) for a lower
+         *   (upper) bound. In turn, the "other bound" must be positive
+         *   (negative) too. Above this "other bound" was "b".
+         * - The implicit sub-products will share other bound. If other bound is
+         *   the upper (lower) bound, then assume that the lower (upper) bound
+         *   of the other interval is positive (negative) or zero. This
+         *   will force the upper (lower) bound of the other interval to be
+         *   positive (negative) too. All bounds will now have the same sign
+         *   and violate one of the inequalities.
+         * - The last possibility is then that the lower (upper) bound of the
+         *   other interval has the opposite sign as the common bound. This too
+         *   will violate one of the inequalities and we conclude that the
+         *   target interval is not possible.
+         */
+
+        if(empty() || rhs.empty()) {
+            return *this = Interval();
+        } else if(width() == 0 && rhs.width() == 0) { // Both points
+            value_t prod = lower() * rhs.lower();
+            return *this = Interval(prod);
+        } else if(width() == 0) { // *this is a point, rhs is an interval
+            auto l             = lower();
+            auto ll            = l * rhs.lower();
+            auto lh            = l * rhs.upper();
+            value_t low        = std::min(ll, lh);
+            value_t high       = std::max(ll, lh);
+            bool lower_is_open = rhs.left_open();
+            bool upper_is_open = rhs.right_open();
+            if(low != ll) {
+                lower_is_open = rhs.right_open();
+                upper_is_open = rhs.right_open();
+            }
+            return *this = Interval(low, high, lower_is_open, upper_is_open);
+        } else if(rhs.width() == 0) { // rhs is point, *this is an interval
+            // Dispatch to *this is point, rhs is interval
+            return *this = (rhs * (*this));
+        }
+        auto ll            = lower() * rhs.lower();
+        auto lh            = lower() * rhs.upper();
+        auto hl            = upper() * rhs.lower();
+        auto hh            = upper() * rhs.upper();
+        auto low           = std::min(std::min(ll, lh), std::min(hl, hh));
+        auto high          = std::max(std::max(ll, lh), std::max(hl, hh));
+        bool lower_is_open = left_open() || rhs.left_open();
+        bool upper_is_open = right_open() || rhs.right_open();
+        // if(low == ll) // default is correct for this case
+        if(low == lh) {
+            lower_is_open = left_open() || rhs.right_open();
+        } else if(low == hl) {
+            lower_is_open = right_open() || rhs.left_open();
+        } else if(low == hh) {
+            lower_is_open = right_open() || rhs.right_open();
+        }
+
+        // if(high == hh) // default is correct for this case
+        if(high == lh) {
+            upper_is_open = left_open() || rhs.right_open();
+        } else if(high == hl) {
+            upper_is_open = right_open() || rhs.left_open();
+        } else if(high == ll) {
+            upper_is_open = left_open() || rhs.left_open();
+        }
+
+        return *this = Interval(low, high, lower_is_open, upper_is_open);
     }
 
     /** @brief In-place multiplication by a scalar
@@ -171,10 +513,7 @@ public:
      *
      *  @throw none No throw guarantee
      */
-    Interval& operator*=(value_t rhs) {
-        m_interval_ *= rhs;
-        return *this;
-    }
+    Interval& operator*=(value_t rhs) { return *this *= Interval(rhs); }
 
     /** @brief In-place division by another interval
      *
@@ -184,8 +523,11 @@ public:
      *  @throw none No throw guarantee
      */
     Interval& operator/=(const Interval& rhs) {
-        m_interval_ /= rhs.m_interval_;
-        return *this;
+        if(empty() || rhs.empty()) {
+            *this = Interval();
+            return *this;
+        }
+        return *this *= value_t(1.0) / rhs;
     }
 
     /** @brief In-place division by a scalar
@@ -195,18 +537,48 @@ public:
      *
      *  @throw none No throw guarantee
      */
-    Interval& operator/=(value_t rhs) {
-        m_interval_ /= rhs;
-        return *this;
+    Interval& operator/=(value_t rhs) { return *this /= Interval(rhs, rhs); }
+
+    /** @brief Print the interval in interval form
+     *
+     *  The interval is printed in the form where closed bounds are represented
+     *  by square brackets and open bounds are represented by parentheses.
+     *
+     *  @return A string representation of the interval.
+     *
+     *  @throw none No throw guarantee
+     */
+    std::string print_interval_form() const {
+        if(empty()) { return "[∅]"; }
+        std::string left_open_str  = left_open() ? "(" : "[";
+        std::string right_open_str = right_open() ? ")" : "]";
+
+        return left_open_str + std::to_string(lower()) + ", " +
+               std::to_string(upper()) + right_open_str;
     }
 
 private:
-    /// The underlying boost interval
-    boost::numeric::interval<value_t> m_interval_;
+    /// Code factorization for throwing when a method doesn't make sense with an
+    /// empty interval.
+    void assert_not_empty_() const {
+        if(empty()) { throw std::domain_error("Interval is empty"); }
+    }
+
+    /// The underlying interval type
+    using interval_t = boost::numeric::interval<value_t>;
+
+    /// Whether the lower bound is open
+    bool m_is_left_open_ = false;
+    /// Whether the upper bound is open
+    bool m_is_right_open_ = false;
+
+    /// The underlying interval. If optional is empty, the interval is empty.
+    std::optional<interval_t> m_interval_;
 
 }; // class Interval
 
-// -- Utility functions --------------------------------------------------------
+// -- Utility functions
+// --------------------------------------------------------
 
 /** @relates Interval
  *  @brief Overload stream insertion to print an interval
@@ -222,6 +594,10 @@ private:
  */
 template<typename ValueType>
 std::ostream& operator<<(std::ostream& os, const Interval<ValueType>& i) {
+    if(i.empty()) {
+        os << " ∅";
+        return os;
+    }
     os << i.median() << "+/-" << i.radius();
     return os;
 }
@@ -239,6 +615,10 @@ std::ostream& operator<<(std::ostream& os, const Interval<ValueType>& i) {
 template<typename T1, typename T2>
 bool operator==(const Interval<T1>& lhs, const Interval<T2>& rhs) {
     if constexpr(!std::is_same_v<T1, T2>) return false;
+    if(lhs.empty() && rhs.empty()) { return true; }
+    if(lhs.empty() || rhs.empty()) { return false; }
+    if(lhs.left_open() != rhs.left_open()) { return false; }
+    if(lhs.right_open() != rhs.right_open()) { return false; }
     return lhs.lower() == rhs.lower() && lhs.upper() == rhs.upper();
 }
 
@@ -257,85 +637,8 @@ bool operator!=(const Interval<T1>& lhs, const Interval<T2>& rhs) {
     return !(lhs == rhs);
 }
 
-/** @relates Interval
- *  @brief Whether one interval is certainly less than another
- *
- *  Returns true only when @p lhs lies entirely below @p rhs, i.e.
- *  lhs.upper() < rhs.lower().
- *
- *  @tparam T1 The numerical type of the left-hand interval
- *  @tparam T2 The numerical type of the right-hand interval
- *  @param lhs The first interval
- *  @param rhs The second interval
- *
- *  @return Whether @p lhs is certainly less than @p rhs
- */
-template<typename T1, typename T2>
-bool operator<(const Interval<T1>& lhs, const Interval<T2>& rhs) {
-    return lhs.upper() < rhs.lower();
-}
-
-/** @relates Interval
- *  @brief Whether one interval is greater than another
- *
- *  @tparam T1 The numerical type of the left-hand interval
- *  @tparam T2 The numerical type of the right-hand interval
- *  @param lhs The first interval
- *  @param rhs The second interval
- *
- *  @return Whether @p lhs is certainly greater than @p rhs
- */
-template<typename T1, typename T2>
-bool operator>(const Interval<T1>& lhs, const Interval<T2>& rhs) {
-    return rhs < lhs;
-}
-
-/** @relates Interval
- *  @brief Whether one interval is less than or equal to another
- *
- *  @tparam T1 The numerical type of the left-hand interval
- *  @tparam T2 The numerical type of the right-hand interval
- *  @param lhs The first interval
- *  @param rhs The second interval
- *
- *  @return Whether @p lhs is less than or equal to @p rhs
- */
-template<typename T1, typename T2>
-bool operator<=(const Interval<T1>& lhs, const Interval<T2>& rhs) {
-    return (lhs == rhs) || (lhs < rhs);
-}
-
-/** @relates Interval
- *  @brief Whether one interval is greater than or equal to another
- *
- *  @tparam T1 The numerical type of the left-hand interval
- *  @tparam T2 The numerical type of the right-hand interval
- *  @param lhs The first interval
- *  @param rhs The second interval
- *
- *  @return Whether @p lhs is greater than or equal to @p rhs
- */
-template<typename T1, typename T2>
-bool operator>=(const Interval<T1>& lhs, const Interval<T2>& rhs) {
-    return (lhs == rhs) || (lhs > rhs);
-}
-
-// -- Arithmetic free functions ------------------------------------------------
-
-/** @relates Interval
- *  @brief Negation of an interval
- *
- *  @tparam T The numerical type of the interval
- *  @param a The interval to negate
- *
- *  @return A new interval with negated bounds
- *
- *  @throw none No throw guarantee
- */
-template<typename T>
-Interval<T> operator-(const Interval<T>& a) {
-    return Interval<T>(-a.upper(), -a.lower());
-}
+// -- Arithmetic free functions
+// ------------------------------------------------
 
 /** @relates Interval
  *  @brief Addition of two intervals
@@ -424,8 +727,8 @@ Interval<T> operator*(T lhs, const Interval<T>& rhs) {
 /** @relates Interval
  *  @brief Division of two intervals
  *
- *  If the interval contains zero the resulting interval will loose most of its
- *  information.
+ *  If the interval contains zero the resulting interval will loose most of
+ * its information.
  *
  *  @tparam T The numerical type of the intervals
  *  @param lhs The left-hand interval
@@ -443,13 +746,17 @@ Interval<T> operator/(Interval<T> lhs, const Interval<T>& rhs) {
 /** @overload */
 template<typename T>
 Interval<T> operator/(Interval<T> lhs, T rhs) {
-    return lhs /= rhs;
+    if(rhs == 0) { throw std::domain_error("Division by zero"); }
+    return lhs *= T(1.0 / rhs);
 }
 
 /** @overload */
 template<typename T>
 Interval<T> operator/(T lhs, const Interval<T>& rhs) {
-    return Interval<T>(lhs, lhs) /= rhs;
+    if(rhs.empty()) { return rhs; }
+    if(rhs.contains(0)) { throw std::domain_error("Division by zero"); }
+    return Interval<T>(lhs / rhs.upper(), lhs / rhs.lower(), rhs.right_open(),
+                       rhs.left_open());
 }
 
 /// Typedef for an interval of floats
@@ -459,3 +766,16 @@ using IFloat = Interval<float>;
 using IDouble = Interval<double>;
 
 } // namespace sigma
+
+namespace std {
+template<typename ValueType>
+struct hash<sigma::Interval<ValueType>> {
+    size_t operator()(const sigma::Interval<ValueType>& i) const {
+        std::size_t hash_low  = std::hash<ValueType>()(i.lower());
+        std::size_t hash_high = std::hash<ValueType>()(i.upper());
+        std::size_t seed      = hash_low;
+        seed ^= hash_high + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        return seed;
+    }
+};
+} // namespace std

--- a/include/sigma/operations/basic.ipp
+++ b/include/sigma/operations/basic.ipp
@@ -19,9 +19,23 @@ Uncertain<T> fabs(const Uncertain<T>& a) {
 
 template<typename T>
 Interval<T> abs(const Interval<T>& a) {
-    auto result = boost::numeric::abs(
-        boost::numeric::interval<T>(a.lower(), a.upper()));
-    return Interval<T>(result.lower(), result.upper());
+    if(a.empty()) { return Interval<T>(); }
+    // If interval is positive already, just return it.
+    if(a.lower() >= 0) { return a; }
+
+    // If interval is completely negative, return the negative of it.
+    if(a.upper() <= 0) { return -a; }
+
+    // We know it straddles zero.
+    auto abs_low  = std::abs(a.lower());
+    auto abs_high = std::abs(a.upper());
+    if(abs_low < abs_high) {
+        return Interval<T>(0, abs_high, false, a.right_open());
+    } else if(abs_low > abs_high) {
+        return Interval<T>(0, abs_low, false, a.left_open());
+    } else { // Equal in magnitude
+        return Interval<T>(0, abs_low, false, a.left_open() && a.right_open());
+    }
 }
 
 template<typename T>

--- a/include/sigma/operations/exponents.ipp
+++ b/include/sigma/operations/exponents.ipp
@@ -106,19 +106,26 @@ Uncertain<T> hypot(const U& a, const Uncertain<T>& b) {
 
 template<typename T>
 Interval<T> sqrt(const Interval<T>& a) {
-    auto result =
-      boost::numeric::sqrt(boost::numeric::interval<T>(a.lower(), a.upper()));
-    return Interval<T>(result.lower(), result.upper());
+    if(a.empty()) { return Interval<T>(); }
+    auto low  = std::sqrt(a.lower());
+    auto high = std::sqrt(a.upper());
+    return Interval<T>(low, high, a.left_open(), a.right_open());
 }
 
 template<typename T>
 Interval<T> exp(const Interval<T>& a) {
-    return Interval<T>(std::exp(a.lower()), std::exp(a.upper()));
+    if(a.empty()) { return Interval<T>(); }
+    auto low  = std::exp(a.lower());
+    auto high = std::exp(a.upper());
+    return Interval<T>(low, high, a.left_open(), a.right_open());
 }
 
 template<typename T>
 Interval<T> log(const Interval<T>& a) {
-    return Interval<T>(std::log(a.lower()), std::log(a.upper()));
+    if(a.empty()) { return Interval<T>(); }
+    auto low  = std::log(a.lower());
+    auto high = std::log(a.upper());
+    return Interval<T>(low, high, a.left_open(), a.right_open());
 }
 
 } // namespace sigma

--- a/tests/unit_tests/test_interval.cpp
+++ b/tests/unit_tests/test_interval.cpp
@@ -714,7 +714,8 @@ TEMPLATE_TEST_CASE("Interval", "", sigma::IFloat, sigma::IDouble) {
 
     SECTION("operator-=") {
         // We just spot check here and rely on operator- for exhaustive testing
-        auto pone_two = &(one_two -= one_two);
+        testing_t copy_one_two(one_two);
+        auto pone_two = &(one_two -= copy_one_two);
         REQUIRE(pone_two == &one_two);
         REQUIRE(one_two == testing_t(-1.0, 1.0));
 
@@ -1116,7 +1117,8 @@ TEMPLATE_TEST_CASE("Interval", "", sigma::IFloat, sigma::IDouble) {
 
     SECTION("operator/=") {
         // Spot check here and rely on operator/ for exhaustive testing
-        auto pone_two = &(one_two /= one_two);
+        testing_t copy_one_two(one_two);
+        auto pone_two = &(one_two /= copy_one_two);
         REQUIRE(pone_two == &one_two);
         REQUIRE(one_two == testing_t(value_t(1.0 / 2.0), value_t(2.0)));
 

--- a/tests/unit_tests/test_interval.cpp
+++ b/tests/unit_tests/test_interval.cpp
@@ -1,3 +1,4 @@
+#include "catch2/catch_test_macros.hpp"
 #include "testing.hpp"
 #include <sigma/sigma.hpp>
 #include <sstream>
@@ -7,36 +8,1210 @@ using testing::test_interval;
 TEMPLATE_TEST_CASE("Interval", "", sigma::IFloat, sigma::IDouble) {
     using testing_t = TestType;
     using value_t   = typename testing_t::value_t;
-    using other_t   = typename testing::test_traits<TestType>::other_t;
+
+    testing_t empty;
+    testing_t one_two(1.0, 2.0);
+    testing_t one_two_left_open(1.0, 2.0, true, false);
+    testing_t one_two_right_open(1.0, 2.0, false, true);
+    testing_t one_two_open(1.0, 2.0, true, true);
 
     SECTION("Constructors") {
+        SECTION("Default") {
+            REQUIRE(empty.empty());
+            REQUIRE(empty.left_open() == false);
+            REQUIRE(empty.right_open() == false);
+        }
+
+        SECTION("With value") {
+            testing_t one(1.0);
+            test_interval(one, 1.0, 1.0);
+            REQUIRE_FALSE(one.empty());
+            REQUIRE(one.left_open() == false);
+            REQUIRE(one.right_open() == false);
+        }
+
         SECTION("With Lower and Upper") {
-            auto value = testing_t(1.0, 2.0);
-            test_interval(value, 1.0, 2.0);
+            SECTION("Closed Interval") {
+                test_interval(one_two, 1.0, 2.0);
+                REQUIRE_FALSE(one_two.empty());
+                REQUIRE(one_two.left_open() == false);
+                REQUIRE(one_two.right_open() == false);
+            }
+            SECTION("Left Open Interval") {
+                test_interval(one_two_left_open, 1.0, 2.0);
+                REQUIRE_FALSE(one_two_left_open.empty());
+                REQUIRE(one_two_left_open.left_open() == true);
+                REQUIRE(one_two_left_open.right_open() == false);
+            }
+            SECTION("Right Open Interval") {
+                test_interval(one_two_right_open, 1.0, 2.0);
+                REQUIRE_FALSE(one_two_right_open.empty());
+                REQUIRE(one_two_right_open.left_open() == false);
+                REQUIRE(one_two_right_open.right_open() == true);
+            }
+            SECTION("Open Interval") {
+                test_interval(one_two_open, 1.0, 2.0);
+                REQUIRE_FALSE(one_two_open.empty());
+                REQUIRE(one_two_open.left_open() == true);
+                REQUIRE(one_two_open.right_open() == true);
+            }
+            SECTION("Edge case: open interval with single value") {
+                testing_t is_empty(1.0, 1.0, true, true);
+                REQUIRE(is_empty == empty);
+                REQUIRE(is_empty.empty());
+                REQUIRE(is_empty.left_open() == false);
+                REQUIRE(is_empty.right_open() == false);
+            }
         }
         SECTION("Copy") {
-            auto first = testing_t(1.0, 2.0);
-            testing_t value(first);
-            test_interval(value, 1.0, 2.0);
-            test_interval(first, 1.0, 2.0);
+            testing_t copy_empty(empty);
+            REQUIRE(copy_empty == empty);
+            REQUIRE(copy_empty.empty());
+
+            testing_t copy_one_two(one_two);
+            test_interval(copy_one_two, 1.0, 2.0);
+            REQUIRE(copy_one_two == one_two);
+
+            testing_t copy_one_two_left_open(one_two_left_open);
+            test_interval(copy_one_two_left_open, 1.0, 2.0);
+            REQUIRE(copy_one_two_left_open == one_two_left_open);
+
+            testing_t copy_one_two_right_open(one_two_right_open);
+            test_interval(copy_one_two_right_open, 1.0, 2.0);
+            REQUIRE(copy_one_two_right_open == one_two_right_open);
+
+            testing_t copy_one_two_open(one_two_open);
+            test_interval(copy_one_two_open, 1.0, 2.0);
+            REQUIRE(copy_one_two_open == one_two_open);
         }
         SECTION("Move") {
-            auto first = testing_t(1.0, 2.0);
-            testing_t value(std::move(first));
-            test_interval(value, 1.0, 2.0);
+            testing_t copy_empty(empty);
+            testing_t move_empty(std::move(empty));
+            REQUIRE(move_empty == copy_empty);
+            REQUIRE(move_empty.empty());
+
+            testing_t copy_one_two(one_two);
+            testing_t move_one_two(std::move(one_two));
+            test_interval(move_one_two, 1.0, 2.0);
+            REQUIRE(move_one_two == copy_one_two);
+
+            testing_t copy_one_two_left_open(one_two_left_open);
+            testing_t move_one_two_left_open(std::move(one_two_left_open));
+            test_interval(move_one_two_left_open, 1.0, 2.0);
+            REQUIRE(move_one_two_left_open == copy_one_two_left_open);
+
+            testing_t copy_one_two_right_open(one_two_right_open);
+            testing_t move_one_two_right_open(std::move(one_two_right_open));
+            test_interval(move_one_two_right_open, 1.0, 2.0);
+            REQUIRE(move_one_two_right_open == copy_one_two_right_open);
+
+            testing_t copy_one_two_open(one_two_open);
+            testing_t move_one_two_open(std::move(one_two_open));
+            test_interval(move_one_two_open, 1.0, 2.0);
+            REQUIRE(move_one_two_open == copy_one_two_open);
         }
         SECTION("Copy Assignment") {
-            auto first = testing_t(1.0, 2.0);
-            auto value = first;
-            test_interval(value, 1.0, 2.0);
-            test_interval(first, 1.0, 2.0);
+            testing_t copy_empty(empty);
+            auto pcopy_empty = &(copy_empty = empty);
+            REQUIRE(pcopy_empty == &copy_empty);
+            REQUIRE(copy_empty == empty);
+
+            testing_t copy_one_two(one_two);
+            auto pcopy_one_two = &(copy_one_two = one_two);
+            REQUIRE(pcopy_one_two == &copy_one_two);
+            REQUIRE(copy_one_two == one_two);
+
+            testing_t copy_one_two_left_open(one_two_left_open);
+            auto pcopy_one_two_left_open =
+              &(copy_one_two_left_open = one_two_left_open);
+            REQUIRE(pcopy_one_two_left_open == &copy_one_two_left_open);
+            REQUIRE(copy_one_two_left_open == one_two_left_open);
+
+            testing_t copy_one_two_right_open(one_two_right_open);
+            auto pcopy_one_two_right_open =
+              &(copy_one_two_right_open = one_two_right_open);
+            REQUIRE(pcopy_one_two_right_open == &copy_one_two_right_open);
+            REQUIRE(copy_one_two_right_open == one_two_right_open);
+
+            testing_t copy_one_two_open(one_two_open);
+            auto pcopy_one_two_open = &(copy_one_two_open = one_two_open);
+            REQUIRE(pcopy_one_two_open == &copy_one_two_open);
+            REQUIRE(copy_one_two_open == one_two_open);
         }
         SECTION("Move Assignment") {
-            auto first = testing_t(1.0, 2.0);
-            auto value = std::move(first);
-            test_interval(value, 1.0, 2.0);
+            testing_t copy_empty(empty);
+            testing_t move_empty;
+            auto pmove_empty = &(move_empty = std::move(copy_empty));
+            REQUIRE(pmove_empty == &move_empty);
+            REQUIRE(move_empty == copy_empty);
+
+            testing_t copy_one_two(one_two);
+            testing_t move_one_two;
+            auto pmove_one_two = &(move_one_two = std::move(copy_one_two));
+            REQUIRE(pmove_one_two == &move_one_two);
+            REQUIRE(move_one_two == copy_one_two);
+
+            testing_t copy_one_two_left_open(one_two_left_open);
+            testing_t move_one_two_left_open;
+            auto pmove_one_two_left_open =
+              &(move_one_two_left_open = std::move(copy_one_two_left_open));
+            REQUIRE(pmove_one_two_left_open == &move_one_two_left_open);
+            REQUIRE(move_one_two_left_open == copy_one_two_left_open);
+
+            testing_t copy_one_two_right_open(one_two_right_open);
+            testing_t move_one_two_right_open;
+            auto pmove_one_two_right_open =
+              &(move_one_two_right_open = std::move(copy_one_two_right_open));
+            REQUIRE(pmove_one_two_right_open == &move_one_two_right_open);
+            REQUIRE(move_one_two_right_open == copy_one_two_right_open);
+
+            testing_t copy_one_two_open(one_two_open);
+            testing_t move_one_two_open;
+            auto pmove_one_two_open =
+              &(move_one_two_open = std::move(copy_one_two_open));
+            REQUIRE(pmove_one_two_open == &move_one_two_open);
+            REQUIRE(move_one_two_open == copy_one_two_open);
         }
     }
+
+    SECTION("width") {
+        REQUIRE(one_two.width() == 1.0);
+        REQUIRE(one_two_left_open.width() == 1.0);
+        REQUIRE(one_two_right_open.width() == 1.0);
+        REQUIRE(one_two_open.width() == 1.0);
+
+        testing_t one_three(1.0, 3.0);
+        REQUIRE(one_three.width() == 2.0);
+
+        testing_t one(1.0, 1.0);
+        REQUIRE(one.width() == 0.0);
+
+        testing_t value(-1.2, 0.0);
+        REQUIRE(value.width() == value_t(1.2));
+
+        REQUIRE_THROWS_AS(empty.width(), std::domain_error);
+    }
+
+    SECTION("median") {
+        REQUIRE(one_two.median() == 1.5);
+        REQUIRE(one_two_left_open.median() == 1.5);
+        REQUIRE(one_two_right_open.median() == 1.5);
+        REQUIRE(one_two_open.median() == 1.5);
+        REQUIRE_THROWS_AS(empty.median(), std::domain_error);
+    }
+
+    SECTION("radius") {
+        REQUIRE(one_two.radius() == 0.5);
+        REQUIRE(one_two_left_open.radius() == 0.5);
+        REQUIRE(one_two_right_open.radius() == 0.5);
+        REQUIRE(one_two_open.radius() == 0.5);
+        REQUIRE_THROWS_AS(empty.radius(), std::domain_error);
+    }
+
+    SECTION("empty") {
+        REQUIRE(empty.empty() == true);
+        REQUIRE(one_two.empty() == false);
+        REQUIRE(one_two_left_open.empty() == false);
+        REQUIRE(one_two_right_open.empty() == false);
+        REQUIRE(one_two_open.empty() == false);
+    }
+
+    SECTION("left_open") {
+        REQUIRE(one_two.left_open() == false);
+        REQUIRE(one_two_left_open.left_open() == true);
+        REQUIRE(one_two_right_open.left_open() == false);
+        REQUIRE(one_two_open.left_open() == true);
+    }
+
+    SECTION("left_closed") {
+        REQUIRE(one_two.left_closed() == true);
+        REQUIRE(one_two_left_open.left_closed() == false);
+        REQUIRE(one_two_right_open.left_closed() == true);
+        REQUIRE(one_two_open.left_closed() == false);
+    }
+
+    SECTION("right_open") {
+        REQUIRE(one_two.right_open() == false);
+        REQUIRE(one_two_left_open.right_open() == false);
+        REQUIRE(one_two_right_open.right_open() == true);
+        REQUIRE(one_two_open.right_open() == true);
+    }
+
+    SECTION("right_closed") {
+        REQUIRE(one_two.right_closed() == true);
+        REQUIRE(one_two_left_open.right_closed() == true);
+        REQUIRE(one_two_right_open.right_closed() == false);
+        REQUIRE(one_two_open.right_closed() == false);
+    }
+
+    SECTION("lower") {
+        REQUIRE(one_two.lower() == 1.0);
+        REQUIRE(one_two_left_open.lower() == 1.0);
+        REQUIRE(one_two_right_open.lower() == 1.0);
+        REQUIRE(one_two_open.lower() == 1.0);
+        REQUIRE_THROWS_AS(empty.lower(), std::domain_error);
+    }
+
+    SECTION("upper") {
+        REQUIRE(one_two.upper() == 2.0);
+        REQUIRE(one_two_left_open.upper() == 2.0);
+        REQUIRE(one_two_right_open.upper() == 2.0);
+        REQUIRE(one_two_open.upper() == 2.0);
+        REQUIRE_THROWS_AS(empty.upper(), std::domain_error);
+    }
+
+    SECTION("contains (value)") {
+        REQUIRE_FALSE(empty.contains(0.0));
+
+        auto one_m_epsilon = std::nextafter(one_two.lower(), value_t(0.0));
+        auto one_p_epsilon = std::nextafter(one_two.lower(), value_t(3.0));
+        auto two_m_epsilon = std::nextafter(one_two.upper(), value_t(0.0));
+        auto two_p_epsilon = std::nextafter(one_two.upper(), value_t(3.0));
+
+        testing_t one(1.0);
+        REQUIRE_FALSE(one.contains(one_m_epsilon));
+        REQUIRE(one.contains(1.0));
+        REQUIRE_FALSE(one.contains(one_p_epsilon));
+
+        REQUIRE_FALSE(one_two.contains(one_m_epsilon));
+        REQUIRE(one_two.contains(1.0));
+        REQUIRE(one_two.contains(one_p_epsilon));
+        REQUIRE(one_two.contains(two_m_epsilon));
+        REQUIRE(one_two.contains(2.0));
+        REQUIRE_FALSE(one_two.contains(two_p_epsilon));
+
+        REQUIRE_FALSE(one_two_left_open.contains(one_m_epsilon));
+        REQUIRE_FALSE(one_two_left_open.contains(1.0));
+        REQUIRE(one_two_left_open.contains(one_p_epsilon));
+        REQUIRE(one_two_left_open.contains(two_m_epsilon));
+        REQUIRE(one_two_left_open.contains(2.0));
+        REQUIRE_FALSE(one_two_left_open.contains(two_p_epsilon));
+
+        REQUIRE_FALSE(one_two_right_open.contains(one_m_epsilon));
+        REQUIRE(one_two_right_open.contains(1.0));
+        REQUIRE(one_two_right_open.contains(one_p_epsilon));
+        REQUIRE(one_two_right_open.contains(two_m_epsilon));
+        REQUIRE_FALSE(one_two_right_open.contains(2.0));
+        REQUIRE_FALSE(one_two_right_open.contains(two_p_epsilon));
+
+        REQUIRE_FALSE(one_two_open.contains(one_m_epsilon));
+        REQUIRE_FALSE(one_two_open.contains(1.0));
+        REQUIRE(one_two_open.contains(one_p_epsilon));
+        REQUIRE(one_two_open.contains(two_m_epsilon));
+        REQUIRE_FALSE(one_two_open.contains(2.0));
+        REQUIRE_FALSE(one_two_open.contains(two_p_epsilon));
+    }
+
+    SECTION("contains (interval)") {
+        REQUIRE(empty.contains(testing_t()));
+        REQUIRE_FALSE(empty.contains(one_two));
+
+        auto one_m_epsilon = std::nextafter(one_two.lower(), value_t(0.0));
+        auto one_p_epsilon = std::nextafter(one_two.lower(), value_t(3.0));
+        auto two_m_epsilon = std::nextafter(one_two.upper(), value_t(0.0));
+        auto two_p_epsilon = std::nextafter(one_two.upper(), value_t(3.0));
+
+        testing_t outside_left(one_m_epsilon, one_p_epsilon);
+        testing_t on_left(value_t(1.0), one_p_epsilon);
+        testing_t inside(one_p_epsilon, two_m_epsilon);
+        testing_t on_right(two_m_epsilon, value_t(2.0));
+        testing_t outside_right(two_m_epsilon, two_p_epsilon);
+
+        REQUIRE(one_two.contains(testing_t()));
+        REQUIRE_FALSE(one_two.contains(outside_left));
+        REQUIRE(one_two.contains(one_two));
+        REQUIRE(one_two.contains(one_two_left_open));
+        REQUIRE(one_two.contains(on_left));
+        REQUIRE(one_two.contains(inside));
+        REQUIRE(one_two.contains(one_two_open));
+        REQUIRE(one_two.contains(on_right));
+        REQUIRE(one_two.contains(one_two_right_open));
+        REQUIRE_FALSE(one_two.contains(outside_right));
+
+        REQUIRE(one_two_left_open.contains(testing_t()));
+        REQUIRE_FALSE(one_two_left_open.contains(outside_left));
+        REQUIRE_FALSE(one_two_left_open.contains(one_two));
+        REQUIRE(one_two_left_open.contains(one_two_left_open));
+        REQUIRE_FALSE(one_two_left_open.contains(on_left));
+        REQUIRE(one_two_left_open.contains(inside));
+        REQUIRE(one_two_left_open.contains(one_two_open));
+        REQUIRE(one_two_left_open.contains(on_right));
+        REQUIRE_FALSE(one_two_left_open.contains(one_two_right_open));
+        REQUIRE_FALSE(one_two_left_open.contains(outside_right));
+
+        REQUIRE(one_two_right_open.contains(testing_t()));
+        REQUIRE_FALSE(one_two_right_open.contains(outside_left));
+        REQUIRE_FALSE(one_two_right_open.contains(one_two));
+        REQUIRE_FALSE(one_two_right_open.contains(one_two_left_open));
+        REQUIRE(one_two_right_open.contains(on_left));
+        REQUIRE(one_two_right_open.contains(inside));
+        REQUIRE(one_two_right_open.contains(one_two_open));
+        REQUIRE_FALSE(one_two_right_open.contains(on_right));
+        REQUIRE(one_two_right_open.contains(one_two_right_open));
+        REQUIRE_FALSE(one_two_right_open.contains(outside_right));
+
+        REQUIRE(one_two_open.contains(testing_t()));
+        REQUIRE_FALSE(one_two_open.contains(outside_left));
+        REQUIRE_FALSE(one_two_open.contains(one_two));
+        REQUIRE_FALSE(one_two_open.contains(one_two_left_open));
+        REQUIRE_FALSE(one_two_open.contains(on_left));
+        REQUIRE(one_two_open.contains(inside));
+        REQUIRE(one_two_open.contains(one_two_open));
+        REQUIRE_FALSE(one_two_open.contains(on_right));
+        REQUIRE_FALSE(one_two_open.contains(one_two_right_open));
+        REQUIRE_FALSE(one_two_open.contains(outside_right));
+    }
+
+    SECTION("set_union") {
+        SECTION("Union with Empty") {
+            REQUIRE(empty.set_union(empty) == empty);
+            REQUIRE(empty.set_union(one_two) == one_two);
+            REQUIRE(empty.set_union(one_two_left_open) == one_two_left_open);
+            REQUIRE(empty.set_union(one_two_right_open) == one_two_right_open);
+            REQUIRE(empty.set_union(one_two_open) == one_two_open);
+        }
+        SECTION("Same interval different openness") {
+            REQUIRE(one_two.set_union(empty) == one_two);
+            REQUIRE(one_two.set_union(one_two) == one_two);
+            REQUIRE(one_two.set_union(one_two_left_open) == one_two);
+            REQUIRE(one_two.set_union(one_two_right_open) == one_two);
+            REQUIRE(one_two.set_union(one_two_open) == one_two);
+
+            REQUIRE(one_two_left_open.set_union(empty) == one_two_left_open);
+            REQUIRE(one_two_left_open.set_union(one_two) == one_two);
+            REQUIRE(one_two_left_open.set_union(one_two_left_open) ==
+                    one_two_left_open);
+            REQUIRE(one_two_left_open.set_union(one_two_right_open) == one_two);
+            REQUIRE(one_two_left_open.set_union(one_two_open) ==
+                    one_two_left_open);
+
+            REQUIRE(one_two_right_open.set_union(empty) == one_two_right_open);
+            REQUIRE(one_two_right_open.set_union(one_two) == one_two);
+            REQUIRE(one_two_right_open.set_union(one_two_left_open) == one_two);
+            REQUIRE(one_two_right_open.set_union(one_two_right_open) ==
+                    one_two_right_open);
+            REQUIRE(one_two_right_open.set_union(one_two_open) ==
+                    one_two_right_open);
+
+            REQUIRE(one_two_open.set_union(empty) == one_two_open);
+            REQUIRE(one_two_open.set_union(one_two) == one_two);
+            REQUIRE(one_two_open.set_union(one_two_left_open) ==
+                    one_two_left_open);
+            REQUIRE(one_two_open.set_union(one_two_right_open) ==
+                    one_two_right_open);
+            REQUIRE(one_two_open.set_union(one_two_open) == one_two_open);
+        }
+        SECTION("Expands left bound") {
+            // We say "one" because "one_point_five" is too long
+            testing_t zero_one(0.0, 1.5);
+            testing_t zero_one_left_open(0.0, 1.5, true, false);
+            testing_t zero_one_right_open(0.0, 1.5, false, true);
+            testing_t zero_one_open(0.0, 1.5, true, true);
+
+            testing_t zero_two(0.0, 2.0);
+            testing_t zero_two_left_open(0.0, 2.0, true, false);
+            testing_t zero_two_right_open(0.0, 2.0, false, true);
+            testing_t zero_two_open(0.0, 2.0, true, true);
+
+            REQUIRE(one_two.set_union(zero_one) == zero_two);
+            REQUIRE(one_two.set_union(zero_one_left_open) ==
+                    zero_two_left_open);
+            REQUIRE(one_two.set_union(zero_one_right_open) == zero_two);
+            REQUIRE(one_two.set_union(zero_one_open) == zero_two_left_open);
+
+            REQUIRE(one_two_left_open.set_union(zero_one) == zero_two);
+            REQUIRE(one_two_left_open.set_union(zero_one_left_open) ==
+                    zero_two_left_open);
+            REQUIRE(one_two_left_open.set_union(zero_one_right_open) ==
+                    zero_two);
+            REQUIRE(one_two_left_open.set_union(zero_one_open) ==
+                    zero_two_left_open);
+
+            REQUIRE(one_two_right_open.set_union(zero_one) ==
+                    zero_two_right_open);
+            REQUIRE(one_two_right_open.set_union(zero_one_left_open) ==
+                    zero_two_open);
+            REQUIRE(one_two_right_open.set_union(zero_one_right_open) ==
+                    zero_two_right_open);
+            REQUIRE(one_two_right_open.set_union(zero_one_open) ==
+                    zero_two_open);
+
+            REQUIRE(one_two_open.set_union(zero_one) == zero_two_right_open);
+            REQUIRE(one_two_open.set_union(zero_one_left_open) ==
+                    zero_two_open);
+            REQUIRE(one_two_open.set_union(zero_one_right_open) ==
+                    zero_two_right_open);
+            REQUIRE(one_two_open.set_union(zero_one_open) == zero_two_open);
+        }
+
+        SECTION("Expands right bound") {
+            testing_t one_three(1.5, 3.0);
+            testing_t one_three_left_open(1.5, 3.0, true, false);
+            testing_t one_three_right_open(1.5, 3.0, false, true);
+            testing_t one_three_open(1.5, 3.0, true, true);
+
+            testing_t one_three2(1.0, 3.0);
+            testing_t one_three2_left_open(1.0, 3.0, true, false);
+            testing_t one_three2_right_open(1.0, 3.0, false, true);
+            testing_t one_three2_open(1.0, 3.0, true, true);
+
+            REQUIRE(one_two.set_union(one_three) == one_three2);
+            REQUIRE(one_two.set_union(one_three_left_open) == one_three2);
+            REQUIRE(one_two.set_union(one_three_right_open) ==
+                    one_three2_right_open);
+            REQUIRE(one_two.set_union(one_three_open) == one_three2_right_open);
+
+            REQUIRE(one_two_left_open.set_union(one_three) ==
+                    one_three2_left_open);
+            REQUIRE(one_two_left_open.set_union(one_three_left_open) ==
+                    one_three2_left_open);
+            REQUIRE(one_two_left_open.set_union(one_three_right_open) ==
+                    one_three2_open);
+            REQUIRE(one_two_left_open.set_union(one_three_open) ==
+                    one_three2_open);
+
+            REQUIRE(one_two_right_open.set_union(one_three) == one_three2);
+            REQUIRE(one_two_right_open.set_union(one_three_left_open) ==
+                    one_three2);
+            REQUIRE(one_two_right_open.set_union(one_three_right_open) ==
+                    one_three2_right_open);
+            REQUIRE(one_two_right_open.set_union(one_three_open) ==
+                    one_three2_right_open);
+
+            REQUIRE(one_two_open.set_union(one_three) == one_three2_left_open);
+            REQUIRE(one_two_open.set_union(one_three_left_open) ==
+                    one_three2_left_open);
+            REQUIRE(one_two_open.set_union(one_three_right_open) ==
+                    one_three2_open);
+            REQUIRE(one_two_open.set_union(one_three_open) == one_three2_open);
+        }
+
+        testing_t disjoint(4.0, 5.0);
+        REQUIRE_THROWS_AS(one_two.set_union(disjoint), std::domain_error);
+    }
+
+    SECTION("set_intersection") {
+        SECTION("Intersection with Empty") {
+            REQUIRE(empty.set_intersection(empty) == empty);
+            REQUIRE(empty.set_intersection(one_two) == empty);
+            REQUIRE(empty.set_intersection(one_two_left_open) == empty);
+            REQUIRE(empty.set_intersection(one_two_right_open) == empty);
+            REQUIRE(empty.set_intersection(one_two_open) == empty);
+        }
+        SECTION("Same interval different openness") {
+            REQUIRE(one_two.set_intersection(empty) == empty);
+            REQUIRE(one_two.set_intersection(one_two) == one_two);
+            REQUIRE(one_two.set_intersection(one_two_left_open) ==
+                    one_two_left_open);
+            REQUIRE(one_two.set_intersection(one_two_right_open) ==
+                    one_two_right_open);
+            REQUIRE(one_two.set_intersection(one_two_open) == one_two_open);
+
+            REQUIRE(one_two_left_open.set_intersection(empty) == empty);
+            REQUIRE(one_two_left_open.set_intersection(one_two) ==
+                    one_two_left_open);
+            REQUIRE(one_two_left_open.set_intersection(one_two_left_open) ==
+                    one_two_left_open);
+            REQUIRE(one_two_left_open.set_intersection(one_two_right_open) ==
+                    one_two_open);
+            REQUIRE(one_two_left_open.set_intersection(one_two_open) ==
+                    one_two_open);
+
+            REQUIRE(one_two_right_open.set_intersection(empty) == empty);
+            REQUIRE(one_two_right_open.set_intersection(one_two) ==
+                    one_two_right_open);
+            REQUIRE(one_two_right_open.set_intersection(one_two_left_open) ==
+                    one_two_open);
+            REQUIRE(one_two_right_open.set_intersection(one_two_right_open) ==
+                    one_two_right_open);
+            REQUIRE(one_two_right_open.set_intersection(one_two_open) ==
+                    one_two_open);
+
+            REQUIRE(one_two_open.set_intersection(empty) == empty);
+            REQUIRE(one_two_open.set_intersection(one_two) == one_two_open);
+            REQUIRE(one_two_open.set_intersection(one_two_left_open) ==
+                    one_two_open);
+            REQUIRE(one_two_open.set_intersection(one_two_right_open) ==
+                    one_two_open);
+            REQUIRE(one_two_open.set_intersection(one_two_open) ==
+                    one_two_open);
+        }
+        SECTION("Expands left bound") {
+            // We say "one" because "one_point_five" is too long
+            testing_t zero_one(0.0, 1.5);
+            testing_t zero_one_left_open(0.0, 1.5, true, false);
+            testing_t zero_one_right_open(0.0, 1.5, false, true);
+            testing_t zero_one_open(0.0, 1.5, true, true);
+
+            testing_t one(1.0, 1.5);
+            testing_t one_left_open(1.0, 1.5, true, false);
+            testing_t one_right_open(1.0, 1.5, false, true);
+            testing_t one_open(1.0, 1.5, true, true);
+
+            REQUIRE(one_two.set_intersection(zero_one) == one);
+            REQUIRE(one_two.set_intersection(zero_one_left_open) == one);
+            REQUIRE(one_two.set_intersection(zero_one_right_open) ==
+                    one_right_open);
+            REQUIRE(one_two.set_intersection(zero_one_open) == one_right_open);
+
+            REQUIRE(one_two_left_open.set_intersection(zero_one) ==
+                    one_left_open);
+            REQUIRE(one_two_left_open.set_intersection(zero_one_left_open) ==
+                    one_left_open);
+            REQUIRE(one_two_left_open.set_intersection(zero_one_right_open) ==
+                    one_open);
+            REQUIRE(one_two_left_open.set_intersection(zero_one_open) ==
+                    one_open);
+
+            REQUIRE(one_two_right_open.set_intersection(zero_one) == one);
+            REQUIRE(one_two_right_open.set_intersection(zero_one_left_open) ==
+                    one);
+            REQUIRE(one_two_right_open.set_intersection(zero_one_right_open) ==
+                    one_right_open);
+            REQUIRE(one_two_right_open.set_intersection(zero_one_open) ==
+                    one_right_open);
+
+            REQUIRE(one_two_open.set_intersection(zero_one) == one_left_open);
+            REQUIRE(one_two_open.set_intersection(zero_one_left_open) ==
+                    one_left_open);
+            REQUIRE(one_two_open.set_intersection(zero_one_right_open) ==
+                    one_open);
+            REQUIRE(one_two_open.set_intersection(zero_one_open) == one_open);
+        }
+
+        SECTION("Expands right bound") {
+            testing_t one_three(1.5, 3.0);
+            testing_t one_three_left_open(1.5, 3.0, true, false);
+            testing_t one_three_right_open(1.5, 3.0, false, true);
+            testing_t one_three_open(1.5, 3.0, true, true);
+
+            testing_t one_two2(1.5, 2.0);
+            testing_t one_two2_left_open(1.5, 2.0, true, false);
+            testing_t one_two2_right_open(1.5, 2.0, false, true);
+            testing_t one_two2_open(1.5, 2.0, true, true);
+
+            REQUIRE(one_two.set_intersection(one_three) == one_two2);
+            REQUIRE(one_two.set_intersection(one_three_left_open) ==
+                    one_two2_left_open);
+            REQUIRE(one_two.set_intersection(one_three_right_open) == one_two2);
+            REQUIRE(one_two.set_intersection(one_three_open) ==
+                    one_two2_left_open);
+
+            REQUIRE(one_two_left_open.set_intersection(one_three) == one_two2);
+            REQUIRE(one_two_left_open.set_intersection(one_three_left_open) ==
+                    one_two2_left_open);
+            REQUIRE(one_two_left_open.set_intersection(one_three_right_open) ==
+                    one_two2);
+            REQUIRE(one_two_left_open.set_intersection(one_three_open) ==
+                    one_two2_left_open);
+
+            REQUIRE(one_two_right_open.set_intersection(one_three) ==
+                    one_two2_right_open);
+            REQUIRE(one_two_right_open.set_intersection(one_three_left_open) ==
+                    one_two2_open);
+            REQUIRE(one_two_right_open.set_intersection(one_three_right_open) ==
+                    one_two2_right_open);
+            REQUIRE(one_two_right_open.set_intersection(one_three_open) ==
+                    one_two2_open);
+
+            REQUIRE(one_two_open.set_intersection(one_three) ==
+                    one_two2_right_open);
+            REQUIRE(one_two_open.set_intersection(one_three_left_open) ==
+                    one_two2_open);
+            REQUIRE(one_two_open.set_intersection(one_three_right_open) ==
+                    one_two2_right_open);
+            REQUIRE(one_two_open.set_intersection(one_three_open) ==
+                    one_two2_open);
+        }
+
+        testing_t disjoint(4.0, 5.0);
+        REQUIRE(one_two.set_intersection(disjoint) == testing_t());
+    }
+
+    SECTION("operator-(void)") {
+        REQUIRE(-empty == empty);
+        REQUIRE(-one_two == testing_t(-2.0, -1.0));
+        REQUIRE(-one_two_left_open == testing_t(-2.0, -1.0, false, true));
+        REQUIRE(-one_two_right_open == testing_t(-2.0, -1.0, true, false));
+        REQUIRE(-one_two_open == testing_t(-2.0, -1.0, true, true));
+    }
+
+    SECTION("operator+=") {
+        // We just spot check here and rely on operator+ for exhaustive testing
+        auto pone_two = &(one_two += one_two);
+        REQUIRE(pone_two == &one_two);
+        REQUIRE(one_two == testing_t(2.0, 4.0));
+
+        auto pempty = &(empty += value_t(2.0));
+        REQUIRE(pempty == &empty);
+        REQUIRE(empty == testing_t(2.0, 2.0));
+    }
+
+    SECTION("operator+") {
+        SECTION("With Interval") {
+            SECTION("Empty") {
+                REQUIRE(empty + one_two == one_two);
+                REQUIRE(one_two + empty == one_two);
+                REQUIRE(empty + one_two_left_open == one_two_left_open);
+                REQUIRE(one_two_left_open + empty == one_two_left_open);
+                REQUIRE(empty + one_two_right_open == one_two_right_open);
+                REQUIRE(one_two_right_open + empty == one_two_right_open);
+                REQUIRE(empty + one_two_open == one_two_open);
+                REQUIRE(one_two_open + empty == one_two_open);
+            }
+            SECTION("Non-empty") {
+                testing_t three_four(3.0, 4.0);
+                testing_t three_four_left_open(3.0, 4.0, true, false);
+                testing_t three_four_right_open(3.0, 4.0, false, true);
+                testing_t three_four_open(3.0, 4.0, true, true);
+
+                testing_t four_six(4.0, 6.0);
+                testing_t four_six_left_open(4.0, 6.0, true, false);
+                testing_t four_six_right_open(4.0, 6.0, false, true);
+                testing_t four_six_open(4.0, 6.0, true, true);
+
+                REQUIRE(one_two + three_four == four_six);
+                REQUIRE(one_two + three_four_left_open == four_six_left_open);
+                REQUIRE(one_two + three_four_right_open == four_six_right_open);
+                REQUIRE(one_two + three_four_open == four_six_open);
+
+                REQUIRE(one_two_left_open + three_four == four_six_left_open);
+                REQUIRE(one_two_left_open + three_four_left_open ==
+                        four_six_left_open);
+                REQUIRE(one_two_left_open + three_four_right_open ==
+                        four_six_open);
+                REQUIRE(one_two_left_open + three_four_open == four_six_open);
+
+                REQUIRE(one_two_right_open + three_four == four_six_right_open);
+                REQUIRE(one_two_right_open + three_four_left_open ==
+                        four_six_open);
+                REQUIRE(one_two_right_open + three_four_right_open ==
+                        four_six_right_open);
+                REQUIRE(one_two_right_open + three_four_open == four_six_open);
+
+                REQUIRE(one_two_open + three_four == four_six_open);
+                REQUIRE(one_two_open + three_four_left_open == four_six_open);
+                REQUIRE(one_two_open + three_four_right_open == four_six_open);
+                REQUIRE(one_two_open + three_four_open == four_six_open);
+            }
+        }
+        SECTION("With Scalar") {
+            value_t two(2.0);
+
+            testing_t two_two(two, two);
+            testing_t three_four(3.0, 4.0);
+            testing_t three_four_left_open(3.0, 4.0, true, false);
+            testing_t three_four_right_open(3.0, 4.0, false, true);
+            testing_t three_four_open(3.0, 4.0, true, true);
+
+            REQUIRE(empty + two == two_two);
+            REQUIRE(one_two + two == three_four);
+            REQUIRE(one_two_left_open + two == three_four_left_open);
+            REQUIRE(one_two_right_open + two == three_four_right_open);
+            REQUIRE(one_two_open + two == three_four_open);
+        }
+    }
+
+    SECTION("operator-=") {
+        // We just spot check here and rely on operator- for exhaustive testing
+        auto pone_two = &(one_two -= one_two);
+        REQUIRE(pone_two == &one_two);
+        REQUIRE(one_two == testing_t(-1.0, 1.0));
+
+        auto pempty = &(empty -= value_t(2.0));
+        REQUIRE(pempty == &empty);
+        REQUIRE(empty == testing_t(-2.0, -2.0));
+    }
+
+    SECTION("operator-") {
+        SECTION("With Interval") {
+            SECTION("Empty") {
+                REQUIRE(empty - one_two == -one_two);
+                REQUIRE(one_two - empty == one_two);
+                REQUIRE(empty - one_two_left_open == -one_two_left_open);
+                REQUIRE(one_two_left_open - empty == one_two_left_open);
+                REQUIRE(empty - one_two_right_open == -one_two_right_open);
+                REQUIRE(one_two_right_open - empty == one_two_right_open);
+                REQUIRE(empty - one_two_open == -one_two_open);
+                REQUIRE(one_two_open - empty == one_two_open);
+            }
+            SECTION("Non-empty") {
+                testing_t three_four(3.0, 4.0);
+                testing_t three_four_left_open(3.0, 4.0, true, false);
+                testing_t three_four_right_open(3.0, 4.0, false, true);
+                testing_t three_four_open(3.0, 4.0, true, true);
+
+                testing_t three_one(-3.0, -1.0);
+                testing_t three_one_left_open(-3.0, -1.0, true, false);
+                testing_t three_one_right_open(-3.0, -1.0, false, true);
+                testing_t three_one_open(-3.0, -1.0, true, true);
+
+                REQUIRE(one_two - three_four == three_one);
+                REQUIRE(one_two - three_four_left_open == three_one_right_open);
+                REQUIRE(one_two - three_four_right_open == three_one_left_open);
+                REQUIRE(one_two - three_four_open == three_one_open);
+
+                REQUIRE(one_two_left_open - three_four == three_one_left_open);
+                REQUIRE(one_two_left_open - three_four_left_open ==
+                        three_one_open);
+                REQUIRE(one_two_left_open - three_four_right_open ==
+                        three_one_left_open);
+                REQUIRE(one_two_left_open - three_four_open == three_one_open);
+
+                REQUIRE(one_two_right_open - three_four ==
+                        three_one_right_open);
+                REQUIRE(one_two_right_open - three_four_left_open ==
+                        three_one_right_open);
+                REQUIRE(one_two_right_open - three_four_right_open ==
+                        three_one_open);
+                REQUIRE(one_two_right_open - three_four_open == three_one_open);
+
+                REQUIRE(one_two_open - three_four == three_one_open);
+                REQUIRE(one_two_open - three_four_left_open == three_one_open);
+                REQUIRE(one_two_open - three_four_right_open == three_one_open);
+                REQUIRE(one_two_open - three_four_open == three_one_open);
+            }
+        }
+        SECTION("With Scalar") {
+            value_t two(2.0);
+
+            testing_t two_two(two, two);
+            testing_t one_zero(-1.0, 0.0);
+            testing_t one_zero_left_open(-1.0, 0.0, true, false);
+            testing_t one_zero_right_open(-1.0, 0.0, false, true);
+            testing_t one_zero_open(-1.0, 0.0, true, true);
+
+            REQUIRE(empty - two == -two_two);
+            REQUIRE(two - empty == two_two);
+            REQUIRE(one_two - two == one_zero);
+            REQUIRE(two - one_two == -one_zero);
+            REQUIRE(one_two_left_open - two == one_zero_left_open);
+            REQUIRE(two - one_two_left_open == -one_zero_left_open);
+            REQUIRE(one_two_right_open - two == one_zero_right_open);
+            REQUIRE(two - one_two_right_open == -one_zero_right_open);
+            REQUIRE(one_two_open - two == one_zero_open);
+            REQUIRE(two - one_two_open == -one_zero_open);
+        }
+    }
+
+    SECTION("operator*=") {
+        // Spot check here and rely on operator* for exhaustive testing
+        auto pone_two = &(one_two *= one_two);
+        REQUIRE(pone_two == &one_two);
+        REQUIRE(one_two == testing_t(1.0, 4.0));
+
+        auto pempty = &(empty *= value_t(2.0));
+        REQUIRE(pempty == &empty);
+        REQUIRE(empty == testing_t());
+    }
+
+    SECTION("operator*") {
+        SECTION("With Interval") {
+            SECTION("Empty") {
+                REQUIRE(empty * one_two == empty);
+                REQUIRE(one_two * empty == empty);
+                REQUIRE(empty * one_two_left_open == empty);
+                REQUIRE(one_two_left_open * empty == empty);
+                REQUIRE(empty * one_two_right_open == empty);
+                REQUIRE(one_two_right_open * empty == empty);
+                REQUIRE(empty * one_two_open == empty);
+                REQUIRE(one_two_open * empty == empty);
+            }
+            SECTION("Non-empty") {
+                SECTION("result == [ll, hh]") {
+                    testing_t rhs(3.0, 4.0);
+                    testing_t rhs_left_open(3.0, 4.0, true, false);
+                    testing_t rhs_right_open(3.0, 4.0, false, true);
+                    testing_t rhs_open(3.0, 4.0, true, true);
+
+                    testing_t result(3.0, 8.0);
+                    testing_t result_left_open(3.0, 8.0, true, false);
+                    testing_t result_right_open(3.0, 8.0, false, true);
+                    testing_t result_open(3.0, 8.0, true, true);
+
+                    REQUIRE(one_two * rhs == result);
+                    REQUIRE(one_two * rhs_left_open == result_left_open);
+                    REQUIRE(one_two * rhs_right_open == result_right_open);
+                    REQUIRE(one_two * rhs_open == result_open);
+
+                    REQUIRE(one_two_left_open * rhs == result_left_open);
+                    REQUIRE(one_two_left_open * rhs_left_open ==
+                            result_left_open);
+                    REQUIRE(one_two_left_open * rhs_right_open == result_open);
+                    REQUIRE(one_two_left_open * rhs_open == result_open);
+
+                    REQUIRE(one_two_right_open * rhs == result_right_open);
+                    REQUIRE(one_two_right_open * rhs_left_open == result_open);
+                    REQUIRE(one_two_right_open * rhs_right_open ==
+                            result_right_open);
+                    REQUIRE(one_two_right_open * rhs_open == result_open);
+
+                    REQUIRE(one_two_open * rhs == result_open);
+                    REQUIRE(one_two_open * rhs_left_open == result_open);
+                    REQUIRE(one_two_open * rhs_right_open == result_open);
+                    REQUIRE(one_two_open * rhs_open == result_open);
+                }
+                SECTION("result == [lh, ll]") {
+                    testing_t rhs(-4.0, 3.0);
+                    testing_t rhs_left_open(-4.0, 3.0, true, false);
+                    testing_t rhs_right_open(-4.0, 3.0, false, true);
+                    testing_t rhs_open(-4.0, 3.0, true, true);
+                    testing_t lhs(-3.0, 2.0);
+                    testing_t lhs_left_open(-3.0, 2.0, true, false);
+                    testing_t lhs_right_open(-3.0, 2.0, false, true);
+                    testing_t lhs_open(-3.0, 2.0, true, true);
+
+                    testing_t result(-9.0, 12.0);
+                    testing_t result_left_open(-9.0, 12.0, true, false);
+                    testing_t result_right_open(-9.0, 12.0, false, true);
+                    testing_t result_open(-9.0, 12.0, true, true);
+
+                    REQUIRE(lhs * rhs == result);
+                    REQUIRE(lhs * rhs_left_open == result_right_open);
+                    REQUIRE(lhs * rhs_right_open == result_left_open);
+                    REQUIRE(lhs * rhs_open == result_open);
+
+                    REQUIRE(lhs_left_open * rhs == result_open);
+                    REQUIRE(lhs_left_open * rhs_left_open == result_open);
+                    REQUIRE(lhs_left_open * rhs_right_open == result_open);
+                    REQUIRE(lhs_left_open * rhs_open == result_open);
+
+                    REQUIRE(lhs_right_open * rhs == result);
+                    REQUIRE(lhs_right_open * rhs_left_open ==
+                            result_right_open);
+                    REQUIRE(lhs_right_open * rhs_right_open ==
+                            result_left_open);
+                    REQUIRE(lhs_right_open * rhs_open == result_open);
+
+                    REQUIRE(lhs_open * rhs == result_open);
+                    REQUIRE(lhs_open * rhs_left_open == result_open);
+                    REQUIRE(lhs_open * rhs_right_open == result_open);
+                    REQUIRE(lhs_open * rhs_open == result_open);
+                }
+                SECTION("result == [lh, hl]") {
+                    testing_t lhs(-4.0, -3.0);
+                    testing_t lhs_left_open(-4.0, -3.0, true, false);
+                    testing_t lhs_right_open(-4.0, -3.0, false, true);
+                    testing_t lhs_open(-4.0, -3.0, true, true);
+
+                    testing_t result(-8.0, -3.0);
+                    testing_t result_left_open(-8.0, -3.0, true, false);
+                    testing_t result_right_open(-8.0, -3.0, false, true);
+                    testing_t result_open(-8.0, -3.0, true, true);
+
+                    REQUIRE(lhs * one_two == result);
+                    REQUIRE(lhs * one_two_left_open == result_right_open);
+                    REQUIRE(lhs * one_two_right_open == result_left_open);
+                    REQUIRE(lhs * one_two_open == result_open);
+
+                    REQUIRE(lhs_left_open * one_two == result_left_open);
+                    REQUIRE(lhs_left_open * one_two_left_open == result_open);
+                    REQUIRE(lhs_left_open * one_two_right_open ==
+                            result_left_open);
+                    REQUIRE(lhs_left_open * one_two_open == result_open);
+
+                    REQUIRE(lhs_right_open * one_two == result_right_open);
+                    REQUIRE(lhs_right_open * one_two_left_open ==
+                            result_right_open);
+                    REQUIRE(lhs_right_open * one_two_right_open == result_open);
+                    REQUIRE(lhs_right_open * one_two_open == result_open);
+
+                    REQUIRE(lhs_open * one_two == result_open);
+                    REQUIRE(lhs_open * one_two_left_open == result_open);
+                    REQUIRE(lhs_open * one_two_right_open == result_open);
+                    REQUIRE(lhs_open * one_two_open == result_open);
+                }
+                SECTION("result == [lh, hh]") {
+                    testing_t lhs(-3.0, 4.0);
+                    testing_t lhs_left_open(-3.0, 4.0, true, false);
+                    testing_t lhs_right_open(-3.0, 4.0, false, true);
+                    testing_t lhs_open(-3.0, 4.0, true, true);
+
+                    testing_t result(-6.0, 8.0);
+                    testing_t result_left_open(-6.0, 8.0, true, false);
+                    testing_t result_right_open(-6.0, 8.0, false, true);
+                    testing_t result_open(-6.0, 8.0, true, true);
+
+                    REQUIRE(lhs * one_two == result);
+                    REQUIRE(lhs * one_two_left_open == result);
+                    REQUIRE(lhs * one_two_right_open == result_open);
+                    REQUIRE(lhs * one_two_open == result_open);
+
+                    REQUIRE(lhs_left_open * one_two == result_left_open);
+                    REQUIRE(lhs_left_open * one_two_left_open ==
+                            result_left_open);
+                    REQUIRE(lhs_left_open * one_two_right_open == result_open);
+                    REQUIRE(lhs_left_open * one_two_open == result_open);
+
+                    REQUIRE(lhs_right_open * one_two == result_right_open);
+                    REQUIRE(lhs_right_open * one_two_left_open ==
+                            result_right_open);
+                    REQUIRE(lhs_right_open * one_two_right_open == result_open);
+                    REQUIRE(lhs_right_open * one_two_open == result_open);
+
+                    REQUIRE(lhs_open * one_two == result_open);
+                    REQUIRE(lhs_open * one_two_left_open == result_open);
+                    REQUIRE(lhs_open * one_two_right_open == result_open);
+                    REQUIRE(lhs_open * one_two_open == result_open);
+                }
+                SECTION("result == [hl, ll]") {
+                    testing_t lhs(-4.0, 3.0);
+                    testing_t lhs_left_open(-4.0, 3.0, true, false);
+                    testing_t lhs_right_open(-4.0, 3.0, false, true);
+                    testing_t lhs_open(-4.0, 3.0, true, true);
+                    testing_t rhs(-3.0, 2.0);
+                    testing_t rhs_left_open(-3.0, 2.0, true, false);
+                    testing_t rhs_right_open(-3.0, 2.0, false, true);
+                    testing_t rhs_open(-3.0, 2.0, true, true);
+
+                    testing_t result(-9.0, 12.0);
+                    testing_t result_left_open(-9.0, 12.0, true, false);
+                    testing_t result_right_open(-9.0, 12.0, false, true);
+                    testing_t result_open(-9.0, 12.0, true, true);
+
+                    REQUIRE(lhs * rhs == result);
+                    REQUIRE(lhs * rhs_left_open == result_open);
+                    REQUIRE(lhs * rhs_right_open == result);
+                    REQUIRE(lhs * rhs_open == result_open);
+
+                    REQUIRE(lhs_left_open * rhs == result_right_open);
+                    REQUIRE(lhs_left_open * rhs_left_open == result_open);
+                    REQUIRE(lhs_left_open * rhs_right_open ==
+                            result_right_open);
+                    REQUIRE(lhs_left_open * rhs_open == result_open);
+
+                    REQUIRE(lhs_right_open * rhs == result_left_open);
+                    REQUIRE(lhs_right_open * rhs_left_open == result_open);
+                    REQUIRE(lhs_right_open * rhs_right_open ==
+                            result_left_open);
+                    REQUIRE(lhs_right_open * rhs_open == result_open);
+
+                    REQUIRE(lhs_open * rhs == result_open);
+                    REQUIRE(lhs_open * rhs_left_open == result_open);
+                    REQUIRE(lhs_open * rhs_right_open == result_open);
+                    REQUIRE(lhs_open * rhs_open == result_open);
+                }
+                SECTION("result == [hl, lh]") {
+                    testing_t rhs(-4.0, -3.0);
+                    testing_t rhs_left_open(-4.0, -3.0, true, false);
+                    testing_t rhs_right_open(-4.0, -3.0, false, true);
+                    testing_t rhs_open(-4.0, -3.0, true, true);
+
+                    testing_t result(-8.0, -3.0);
+                    testing_t result_left_open(-8.0, -3.0, true, false);
+                    testing_t result_right_open(-8.0, -3.0, false, true);
+                    testing_t result_open(-8.0, -3.0, true, true);
+
+                    REQUIRE(one_two * rhs == result);
+                    REQUIRE(one_two * rhs_left_open == result_left_open);
+                    REQUIRE(one_two * rhs_right_open == result_right_open);
+                    REQUIRE(one_two * rhs_open == result_open);
+
+                    REQUIRE(one_two_left_open * rhs == result_right_open);
+                    REQUIRE(one_two_left_open * rhs_left_open == result_open);
+                    REQUIRE(one_two_left_open * rhs_right_open ==
+                            result_right_open);
+                    REQUIRE(one_two_left_open * rhs_open == result_open);
+
+                    REQUIRE(one_two_right_open * rhs == result_left_open);
+                    REQUIRE(one_two_right_open * rhs_left_open ==
+                            result_left_open);
+                    REQUIRE(one_two_right_open * rhs_right_open == result_open);
+                    REQUIRE(one_two_right_open * rhs_open == result_open);
+
+                    REQUIRE(one_two_open * rhs == result_open);
+                    REQUIRE(one_two_open * rhs_left_open == result_open);
+                    REQUIRE(one_two_open * rhs_right_open == result_open);
+                    REQUIRE(one_two_open * rhs_open == result_open);
+                }
+                SECTION("result == [hl, hh]") {
+                    testing_t rhs(-3.0, 4.0);
+                    testing_t rhs_left_open(-3.0, 4.0, true, false);
+                    testing_t rhs_right_open(-3.0, 4.0, false, true);
+                    testing_t rhs_open(-3.0, 4.0, true, true);
+
+                    testing_t result(-6.0, 8.0);
+                    testing_t result_left_open(-6.0, 8.0, true, false);
+                    testing_t result_right_open(-6.0, 8.0, false, true);
+                    testing_t result_open(-6.0, 8.0, true, true);
+
+                    REQUIRE(one_two * rhs == result);
+                    REQUIRE(one_two * rhs_left_open == result_left_open);
+                    REQUIRE(one_two * rhs_right_open == result_right_open);
+                    REQUIRE(one_two * rhs_open == result_open);
+
+                    REQUIRE(one_two_left_open * rhs == result);
+                    REQUIRE(one_two_left_open * rhs_left_open ==
+                            result_left_open);
+                    REQUIRE(one_two_left_open * rhs_right_open ==
+                            result_right_open);
+                    REQUIRE(one_two_left_open * rhs_open == result_open);
+
+                    REQUIRE(one_two_right_open * rhs == result_open);
+                    REQUIRE(one_two_right_open * rhs_left_open == result_open);
+                    REQUIRE(one_two_right_open * rhs_right_open == result_open);
+                    REQUIRE(one_two_right_open * rhs_open == result_open);
+
+                    REQUIRE(one_two_open * rhs == result_open);
+                    REQUIRE(one_two_open * rhs_left_open == result_open);
+                    REQUIRE(one_two_open * rhs_right_open == result_open);
+                    REQUIRE(one_two_open * rhs_open == result_open);
+                }
+                SECTION("result == [hh,ll]") {
+                    testing_t lhs(-4.0, -3.0);
+                    testing_t lhs_left_open(-4.0, -3.0, true, false);
+                    testing_t lhs_right_open(-4.0, -3.0, false, true);
+                    testing_t lhs_open(-4.0, -3.0, true, true);
+                    testing_t rhs(-2.0, -1.0);
+                    testing_t rhs_left_open(-2.0, -1.0, true, false);
+                    testing_t rhs_right_open(-2.0, -1.0, false, true);
+                    testing_t rhs_open(-2.0, -1.0, true, true);
+
+                    testing_t result(3.0, 8.0);
+                    testing_t result_left_open(3.0, 8.0, true, false);
+                    testing_t result_right_open(3.0, 8.0, false, true);
+                    testing_t result_open(3.0, 8.0, true, true);
+
+                    REQUIRE(lhs * rhs == result);
+                    REQUIRE(lhs * rhs_left_open == result_right_open);
+                    REQUIRE(lhs * rhs_right_open == result_left_open);
+                    REQUIRE(lhs * rhs_open == result_open);
+
+                    REQUIRE(lhs_left_open * rhs == result_right_open);
+                    REQUIRE(lhs_left_open * rhs_left_open == result_right_open);
+                    REQUIRE(lhs_left_open * rhs_right_open == result_open);
+                    REQUIRE(lhs_left_open * rhs_open == result_open);
+
+                    REQUIRE(lhs_right_open * rhs == result_left_open);
+                    REQUIRE(lhs_right_open * rhs_left_open == result_open);
+                    REQUIRE(lhs_right_open * rhs_right_open ==
+                            result_left_open);
+                    REQUIRE(lhs_right_open * rhs_open == result_open);
+
+                    REQUIRE(lhs_open * rhs == result_open);
+                    REQUIRE(lhs_open * rhs_left_open == result_open);
+                    REQUIRE(lhs_open * rhs_right_open == result_open);
+                    REQUIRE(lhs_open * rhs_open == result_open);
+                }
+            }
+            SECTION("value") {
+                value_t two(2.0);
+
+                testing_t result(2.0, 4.0);
+                testing_t result_left_open(2.0, 4.0, true, false);
+                testing_t result_right_open(2.0, 4.0, false, true);
+                testing_t result_open(2.0, 4.0, true, true);
+
+                REQUIRE(one_two * two == result);
+                REQUIRE(two * one_two == result);
+                REQUIRE(one_two_left_open * two == result_left_open);
+                REQUIRE(two * one_two_left_open == result_left_open);
+                REQUIRE(one_two_right_open * two == result_right_open);
+                REQUIRE(two * one_two_right_open == result_right_open);
+                REQUIRE(one_two_open * two == result_open);
+                REQUIRE(two * one_two_open == result_open);
+            }
+        }
+    }
+
+    SECTION("operator/=") {
+        // Spot check here and rely on operator/ for exhaustive testing
+        auto pone_two = &(one_two /= one_two);
+        REQUIRE(pone_two == &one_two);
+        REQUIRE(one_two == testing_t(value_t(1.0 / 2.0), value_t(2.0)));
+
+        auto pempty = &(empty /= value_t(2.0));
+        REQUIRE(pempty == &empty);
+        REQUIRE(empty == testing_t());
+    }
+
+    SECTION("operator/") {
+        SECTION("With Interval") {
+            SECTION("Empty") {
+                REQUIRE(empty / one_two == empty);
+                REQUIRE(one_two / empty == empty);
+                REQUIRE(empty / one_two_left_open == empty);
+                REQUIRE(one_two_left_open / empty == empty);
+                REQUIRE(empty / one_two_right_open == empty);
+            }
+            SECTION("Non-empty") {
+                // The implementation consists of calling
+                // 1. 1.0 / rhs.
+                // 2. multiplying lhs by the result of 1.
+                // Step 1 is tested in the "With Value" section below and works.
+                // Step 2 is tested in the operator* section above and works.
+                // We just spot check here.
+
+                testing_t result(0.5, 2.0);
+                testing_t result_left_open(0.5, 2.0, true, false);
+                testing_t result_right_open(0.5, 2.0, false, true);
+                testing_t result_open(0.5, 2.0, true, true);
+
+                REQUIRE(one_two / one_two == result);
+
+                REQUIRE(one_two_left_open / one_two == result_left_open);
+                REQUIRE(one_two / one_two_left_open == result_right_open);
+
+                REQUIRE(one_two_right_open / one_two == result_right_open);
+                REQUIRE(one_two / one_two_right_open == result_left_open);
+
+                REQUIRE(one_two_open / one_two == result_open);
+                REQUIRE(one_two / one_two_right_open == result_left_open);
+
+                REQUIRE_THROWS_AS(one_two / value_t(0.0), std::domain_error);
+                REQUIRE_THROWS_AS(one_two / testing_t(-1.0, 1.0),
+                                  std::domain_error);
+            }
+        }
+        SECTION("With Value") {
+            value_t two(2.0);
+
+            // Result when two is on left side
+            testing_t result_lhs(1.0, 2.0);
+            testing_t result_lhs_left_open(1.0, 2.0, true, false);
+            testing_t result_lhs_right_open(1.0, 2.0, false, true);
+            testing_t result_lhs_open(1.0, 2.0, true, true);
+
+            // Result when two is on right side
+            testing_t result_rhs(0.5, 1.0);
+            testing_t result_rhs_left_open(0.5, 1.0, true, false);
+            testing_t result_rhs_right_open(0.5, 1.0, false, true);
+            testing_t result_rhs_open(0.5, 1.0, true, true);
+            testing_t result_open(1.0, 2.0, true, true);
+
+            REQUIRE(empty / two == empty);
+            REQUIRE(two / empty == empty);
+
+            REQUIRE(one_two / two == result_rhs);
+            REQUIRE(two / one_two == result_lhs);
+
+            REQUIRE(one_two_left_open / two == result_rhs_left_open);
+            REQUIRE(two / one_two_left_open == result_lhs_right_open);
+
+            REQUIRE(one_two_right_open / two == result_rhs_right_open);
+            REQUIRE(two / one_two_right_open == result_lhs_left_open);
+
+            REQUIRE(one_two_open / two == result_rhs_open);
+            REQUIRE(two / one_two_open == result_lhs_open);
+
+            REQUIRE_THROWS_AS(one_two / value_t(0.0), std::domain_error);
+            REQUIRE_THROWS_AS(two / testing_t(-1.0, 1.0), std::domain_error);
+        }
+    }
+
+    SECTION("print_interval_form") {
+        std::stringstream ss;
+        ss << std::to_string(one_two.lower()) << ", "
+           << std::to_string(one_two.upper());
+        auto guts = ss.str();
+
+        REQUIRE(one_two.print_interval_form() == "[" + guts + "]");
+        REQUIRE(one_two_left_open.print_interval_form() == "(" + guts + "]");
+        REQUIRE(one_two_right_open.print_interval_form() == "[" + guts + ")");
+        REQUIRE(one_two_open.print_interval_form() == "(" + guts + ")");
+        REQUIRE(empty.print_interval_form() == "[∅]");
+    }
+
     SECTION("operator<<(std::ostream, Interval)") {
         value_t lo = 1.0, hi = 2.0;
         auto value = testing_t(lo, hi);
@@ -45,168 +1220,42 @@ TEMPLATE_TEST_CASE("Interval", "", sigma::IFloat, sigma::IDouble) {
         corr << value.median() << "+/-" << value.radius();
         REQUIRE(ss.str() == corr.str());
     }
-    SECTION("Comparisons") {
-        auto first = testing_t(1.0, 2.0);
-        SECTION("Same") {
-            auto second = first;
-            REQUIRE(first == second);
-            REQUIRE_FALSE(first != second);
-        }
-        SECTION("Different Value Type") {
-            auto second = other_t(1.0, 2.0);
-            REQUIRE_FALSE(first == second);
-        }
-        SECTION("Different Lower") {
-            auto second = testing_t(0.5, 2.0);
-            REQUIRE_FALSE(first == second);
-            REQUIRE(first != second);
-        }
-        SECTION("Different Upper") {
-            auto second = testing_t(1.0, 3.0);
-            REQUIRE_FALSE(first == second);
-            REQUIRE(first != second);
-        }
-        SECTION("Relative") {
-            // [1,2] is certainly less than [3,4]
-            auto second = testing_t(3.0, 4.0);
-            // [1.5, 2.5] overlaps with [1,2]
-            auto third = testing_t(1.5, 2.5);
-            SECTION("Less than") {
-                REQUIRE(first < second);
-                REQUIRE(third < second);
-                REQUIRE_FALSE(second < first);
-                REQUIRE_FALSE(first < third);
-            }
-            SECTION("Greater than") {
-                REQUIRE(second > first);
-                REQUIRE(second > third);
-                REQUIRE_FALSE(first > second);
-                REQUIRE_FALSE(third > first);
-            }
-            SECTION("Less than or equal") {
-                REQUIRE(first <= second);
-                REQUIRE(third <= second);
-                REQUIRE_FALSE(second <= first);
-                REQUIRE_FALSE(first <= third);
-            }
-            SECTION("Greater than or equal") {
-                REQUIRE(second >= first);
-                REQUIRE(second >= third);
-                REQUIRE_FALSE(first >= second);
-                REQUIRE_FALSE(third >= first);
-            }
-        }
+
+    SECTION("operator==") {
+        REQUIRE(one_two == testing_t(1.0, 2.0));
+        REQUIRE_FALSE(one_two == one_two_left_open);
+        REQUIRE_FALSE(one_two == one_two_right_open);
+        REQUIRE_FALSE(one_two == one_two_open);
+        REQUIRE_FALSE(one_two == empty);
+
+        REQUIRE(one_two_left_open == testing_t(1.0, 2.0, true, false));
+        REQUIRE_FALSE(one_two_left_open == one_two);
+        REQUIRE_FALSE(one_two_left_open == one_two_right_open);
+        REQUIRE_FALSE(one_two_left_open == one_two_open);
+        REQUIRE_FALSE(one_two_left_open == empty);
+
+        REQUIRE(one_two_right_open == testing_t(1.0, 2.0, false, true));
+        REQUIRE_FALSE(one_two_right_open == one_two);
+        REQUIRE_FALSE(one_two_right_open == one_two_left_open);
+        REQUIRE_FALSE(one_two_right_open == one_two_open);
+        REQUIRE_FALSE(one_two_right_open == empty);
+
+        REQUIRE(one_two_open == testing_t(1.0, 2.0, true, true));
+        REQUIRE_FALSE(one_two_open == one_two);
+        REQUIRE_FALSE(one_two_open == one_two_left_open);
+        REQUIRE_FALSE(one_two_open == one_two_right_open);
+        REQUIRE_FALSE(one_two_open == empty);
+
+        REQUIRE(empty == testing_t());
+        REQUIRE_FALSE(empty == one_two);
+        REQUIRE_FALSE(empty == one_two_left_open);
+        REQUIRE_FALSE(empty == one_two_right_open);
+        REQUIRE_FALSE(empty == one_two_open);
     }
-    SECTION("contains") {
-        auto interval = testing_t(value_t{1}, value_t{3});
 
-        SECTION("interior") { REQUIRE(interval.contains(value_t{2})); }
-
-        SECTION("endpoints are included") {
-            REQUIRE(interval.contains(value_t{1}));
-            REQUIRE(interval.contains(value_t{3}));
-        }
-
-        SECTION("outside") {
-            REQUIRE_FALSE(interval.contains(value_t{0.99}));
-            REQUIRE_FALSE(interval.contains(value_t{3.01}));
-        }
-
-        SECTION("degenerate interval (single point)") {
-            auto point = testing_t(value_t{5}, value_t{5});
-            REQUIRE(point.contains(value_t{5}));
-            REQUIRE_FALSE(point.contains(value_t{4.99}));
-            REQUIRE_FALSE(point.contains(value_t{5.01}));
-        }
-
-        SECTION("default constructed [0, 0]") {
-            testing_t zero{};
-            REQUIRE(zero.contains(value_t{0}));
-            REQUIRE_FALSE(zero.contains(value_t{-0.01}));
-            REQUIRE_FALSE(zero.contains(value_t{0.01}));
-        }
-    }
-    SECTION("Arithmetic") {
-        // a = [1, 3], b = [2, 4]
-        auto a = testing_t(value_t{1}, value_t{3});
-        auto b = testing_t(value_t{2}, value_t{4});
-
-        SECTION("Negation") { test_interval(-a, -3.0, -1.0); }
-        SECTION("Addition") {
-            SECTION("With Interval") { test_interval(a + b, 3.0, 7.0); }
-            SECTION("With Scalar") {
-                test_interval(a + value_t{1}, 2.0, 4.0);
-                test_interval(value_t{1} + a, 2.0, 4.0);
-            }
-        }
-        SECTION("Addition Assignment") {
-            SECTION("With Interval") {
-                auto x = a;
-                x += b;
-                test_interval(x, 3.0, 7.0);
-            }
-            SECTION("With Scalar") {
-                auto x = a;
-                x += value_t{1};
-                test_interval(x, 2.0, 4.0);
-            }
-        }
-        SECTION("Subtraction") {
-            SECTION("With Interval") { test_interval(a - b, -3.0, 1.0); }
-            SECTION("With Scalar") {
-                test_interval(a - value_t{1}, 0.0, 2.0);
-                test_interval(value_t{1} - a, -2.0, 0.0);
-            }
-        }
-        SECTION("Subtraction Assignment") {
-            SECTION("With Interval") {
-                auto x = a;
-                x -= b;
-                test_interval(x, -3.0, 1.0);
-            }
-            SECTION("With Scalar") {
-                auto x = a;
-                x -= value_t{1};
-                test_interval(x, 0.0, 2.0);
-            }
-        }
-        SECTION("Multiplication") {
-            SECTION("By Interval") { test_interval(a * b, 2.0, 12.0); }
-            SECTION("By Scalar") {
-                test_interval(a * value_t{2}, 2.0, 6.0);
-                test_interval(value_t{2} * a, 2.0, 6.0);
-            }
-        }
-        SECTION("Multiplication Assignment") {
-            SECTION("By Interval") {
-                auto x = a;
-                x *= b;
-                test_interval(x, 2.0, 12.0);
-            }
-            SECTION("By Scalar") {
-                auto x = a;
-                x *= value_t{2};
-                test_interval(x, 2.0, 6.0);
-            }
-        }
-        SECTION("Division") {
-            SECTION("By Interval") { test_interval(a / b, 0.25, 1.5); }
-            SECTION("By Scalar") {
-                test_interval(a / value_t{2}, 0.5, 1.5);
-                test_interval(value_t{2} / a, 0.6667, 2.0);
-            }
-        }
-        SECTION("Division Assignment") {
-            SECTION("By Interval") {
-                auto x = a;
-                x /= b;
-                test_interval(x, 0.25, 1.5);
-            }
-            SECTION("By Scalar") {
-                auto x = a;
-                x /= value_t{2};
-                test_interval(x, 0.5, 1.5);
-            }
-        }
+    SECTION("operator!=") {
+        // Just negates operator== so spot check is fine.
+        REQUIRE(one_two != one_two_left_open);
+        REQUIRE_FALSE(one_two != one_two);
     }
 }


### PR DESCRIPTION
Title. I needed open intervals to implement partitioned affine intervals. 

AFAIK Boost only supports closed intervals, so I rolled the logic myself. This created a rather nasty series of if/else statements on the backend of the Interval class. I strongly suspect the open/closed-ness of an operation follows some sort of boolean algebra and can be optimized by working that algebra out. That's a task for another day. For now, the focus is on correctness.