### PR TITLE
Zero threshold for `sigma::uncertain`

### DIFF
--- a/include/sigma/detail_/operation_common.hpp
+++ b/include/sigma/detail_/operation_common.hpp
@@ -67,28 +67,6 @@ void inplace_binary(Uncertain<T>& c, const Uncertain<T>& b, T mean, T dcda,
     c_setter.update_derivatives(b.deps(), dcdb);
 }
 
-/** @brief Generalized Binary Changes
- *
- *  @tparam T The value type of the variable
- *  @param a The variable being altered copied
- *  @param b The variable whose dependencies are being added to @p a's
- *  @param mean The new mean value of the variable
- *  @param dcda The partial derivative being added to the chain from @p a
- *  @param dcdb The partial derivative being added to the chain from @p b
- *
- *  @return A variable with the new mean value and the dependencies of @p a and
- *          @p b, altered respectively by @p dcda and @p dcdb.
- *
- *  @throw none No throw guarantee
- */
-template<typename T>
-Uncertain<T> binary_result(const Uncertain<T>& a, const Uncertain<T>& b, T mean,
-                           T dcda, T dcdb) {
-    Uncertain<T> c(a);
-    detail_::inplace_binary(c, b, mean, dcda, dcdb);
-    return c;
-}
-
 /** @brief Compute the numeric derivative of a function
  *
  *  @tparam FunctionType The type of the function @p f

--- a/include/sigma/detail_/setter.hpp
+++ b/include/sigma/detail_/setter.hpp
@@ -59,8 +59,8 @@ public:
      *  @throw none No throw guarantee
      */
     void update_mean(value_t mean) {
-        if(std::abs(m_x_.m_mean_ - mean) < m_x_.threshold()) return;
-        m_x_.m_mean_ = mean;
+        if(std::abs(m_x_.m_mean_ - mean) >= m_x_.threshold())
+            m_x_.m_mean_ = mean;
     }
 
     /** @brief Recalculate the standard deviation of the wrapped variable from

--- a/include/sigma/detail_/setter.hpp
+++ b/include/sigma/detail_/setter.hpp
@@ -37,6 +37,9 @@ public:
     /// The type of the map holding the variable's dependencies
     using deps_map_t = typename uncertain_t::deps_map_t;
 
+    /// The type of a vector of dependencies of this variable
+    using deps_vector_t = typename std::vector<dep_sd_ptr>;
+
     /** @brief Construct a Setter for a variable
      *
      *  @param u The uncertain variable *this will modify.
@@ -47,39 +50,84 @@ public:
 
     /** @brief Update the mean of the wrapped variable
      *
+     *  If the difference between the new mean and the current mean is below the
+     *  zero threshold, the update is ignored. Otherwise, the mean is updated to
+     *  the new value.
+     *
      *  @param mean The new mean value of the variable
      *
      *  @throw none No throw guarantee
      */
-    void update_mean(value_t mean) { m_x_.m_mean_ = mean; }
+    void update_mean(value_t mean) {
+        if(std::abs(m_x_.m_mean_ - mean) < m_x_.threshold()) return;
+        m_x_.m_mean_ = mean;
+    }
+
+    /** @brief Recalculate the standard deviation of the wrapped variable from
+     *         its dependencies.
+     *
+     *  @throw none No throw guarantee
+     */
+    void recalculate_sd() {
+        m_x_.m_sd_ = 0.0;
+        for(const auto& [dep, deriv] : m_x_.m_deps_) {
+            m_x_.m_sd_ += std::pow(*dep.get() * deriv, 2.0);
+        }
+        m_x_.m_sd_ = std::sqrt(m_x_.m_sd_);
+    }
 
     /** @brief Update of existing derivatives
+     *
+     *  Updates the partial derivatives of the variable with respect to its
+     *  dependencies, taking into account that some may be reduced below the
+     *  zero threshold and need to be removed from the dependencies map. If so,
+     *  the standard deviation will be updated accordingly.
      *
      *  @param dxda The partial derivative of the variable
      *
      *  @throw none No throw guarantee
      */
     void update_derivatives(value_t dxda) {
-        // If the derivative is one, we don't need to do anything since the
-        // derivatives are unchanged
-        if(dxda == 1.0) return;
-        // If the derivative is zero, we can just clear the dependencies and set
-        // the standard deviation to zero
-        if(dxda == 0.0) {
+        // If the derivative is effectively zero, we can just clear the
+        // dependencies and set the standard deviation to zero.
+        if(std::abs(dxda) < m_x_.threshold() || dxda == 0.0) {
             m_x_.m_deps_.clear();
             m_x_.m_sd_ = 0.0;
             return;
         }
-        // Update the derivatives in place
+        // If the derivative is one, we don't need to do anything since the
+        // derivatives are unchanged.
+        if(dxda == 1.0) return;
+        // Update the derivatives in place, tracking any that are reduced below
+        // our threshold and will need to be removed from the dependencies map.
+        m_removed_deps_.clear();
         for(const auto& [dep, deriv] : m_x_.m_deps_) {
             m_x_.m_deps_[dep] *= dxda;
+            if(std::abs(m_x_.m_deps_[dep]) < m_x_.threshold()) {
+                m_removed_deps_.emplace_back(dep);
+            }
         }
-        // If the derivative is not negative one, we need to update the
-        // standard deviation as well.
-        if(dxda != -1.0) { m_x_.m_sd_ *= std::abs(dxda); }
+        // If no dependencies need to be removed, we can just update the
+        // standard deviation by multiplying by the absolute value of the
+        // partial derivative. If the partial derivate is negative one, we don't
+        // need to update the standard deviation since it is unchanged. If any
+        // dependencies were reduced below our threshold, we need to remove them
+        // from the dependencies map and recalculate the standard deviation.
+        if(m_removed_deps_.size() == 0) {
+            if(dxda != -1.0) m_x_.m_sd_ *= std::abs(dxda);
+        } else {
+            for(const auto& dep : m_removed_deps_) m_x_.m_deps_.erase(dep);
+            recalculate_sd();
+        }
     }
 
     /** @brief Update/addition of derivatives
+     *
+     *  Updates the map of dependencies and their derivatives with the provided
+     *  map, while ignoring any new dependencies or contributions that are below
+     *  the zero threshold. If any existing dependencies are reduced below the
+     *  zero threshold, they will be removed from the dependencies map and the
+     *  standard deviation will be updated accordingly.
      *
      *  @param deps The dependencies to update
      *  @param dxda The partial derivative of this variable with respect to
@@ -89,25 +137,28 @@ public:
      */
     void update_derivatives(const deps_map_t& deps, value_t dxda) {
         // If the derivative is zero, we can skip the update since it won't
-        // change anything
-        if(dxda == 0.0) { return; }
-
+        // change anything.
+        if(std::abs(dxda) < m_x_.threshold() || dxda == 0.0) { return; }
         // Update the map of contributions and their derivatives, keeping track
-        // of any that are reduced to zero and will need to be removed.
-        std::vector<dep_sd_ptr> zero_contributions{};
+        // of any that are reduced to zero and will need to be removed. If the
+        // uncertainty or contribution of a new dependency is below the
+        // threshold, we can skip adding it to the map.
+        m_removed_deps_.clear();
         size_t n_updated = 0;
         for(const auto& [dep, deriv] : deps) {
             if(m_x_.m_deps_.count(dep)) {
                 m_x_.m_deps_[dep] += dxda * deriv;
-                if(m_x_.m_deps_[dep] == 0.0) {
-                    zero_contributions.emplace_back(dep);
+                if(std::abs(m_x_.m_deps_[dep]) < m_x_.threshold() ||
+                   m_x_.m_deps_[dep] == 0.0) {
+                    m_removed_deps_.emplace_back(dep);
                 }
                 n_updated++;
             } else {
+                if(std::abs(dxda * deriv) < m_x_.threshold()) continue;
+                if(std::abs(*dep.get()) < m_x_.threshold()) continue;
                 m_x_.m_deps_.emplace(dep, dxda * deriv);
             }
         }
-
         // If more than half of the existing dependencies are being updated,
         // it's more efficient to update the derivatives and then recalculate
         // the standard deviation from scratch. Otherwise, we can update the
@@ -115,23 +166,18 @@ public:
         // zeroed and updated dependencies and then adding the new contribution
         // of the updated dependencies.
         if(n_updated > (m_x_.m_deps_.size() / 2)) {
-            // Remove from m_deps_ any dependency that was reduced to zero.
-            for(const auto& dep : zero_contributions) {
-                m_x_.m_deps_.erase(dep);
-            }
-
-            // Recalculate the variance.
-            m_x_.m_sd_ = 0.0;
-            for(const auto& [dep, deriv] : m_x_.m_deps_) {
-                m_x_.m_sd_ += std::pow(*dep.get() * deriv, 2.0);
-            }
+            for(const auto& dep : m_removed_deps_) m_x_.m_deps_.erase(dep);
+            recalculate_sd();
         } else {
             // Return to the variance so we can update the sum.
             m_x_.m_sd_ = std::pow(m_x_.m_sd_, 2.0);
-
-            // Step through the updated dependencies and update the variance
+            // Step through the updated dependencies and update the variance.
             // accordingly.
             for(const auto& [dep, deriv] : deps) {
+                // Skip any dependencies that aren't in the map at this point.
+                if(!m_x_.m_deps_.count(dep)) continue;
+                // Calculate the previous value of the derivative for this
+                // dependency.
                 auto old_deriv = m_x_.m_deps_[dep] - dxda * deriv;
                 // As long as the dependency hasn't been reduce to zero, we need
                 // to add its contribution to the variance.
@@ -144,19 +190,18 @@ public:
                     m_x_.m_sd_ -= std::pow(*dep.get() * old_deriv, 2.0);
                 }
             }
-
-            // Remove from m_deps_ any dependency that was reduced to zero.
-            for(const auto& dep : zero_contributions) {
-                m_x_.m_deps_.erase(dep);
-            }
+            m_x_.m_sd_ = std::sqrt(m_x_.m_sd_);
+            for(const auto& dep : m_removed_deps_) m_x_.m_deps_.erase(dep);
         }
-        // Take the square root of the variance to get the standard deviation.
-        m_x_.m_sd_ = std::sqrt(m_x_.m_sd_);
     }
 
 private:
-    /// The variable being modified
+    /// The variable being modified.
     uncertain_t& m_x_;
+
+    /// Buffer for dependencies that are reduced to zero during an update, so we
+    /// can remove them from the dependencies map.
+    deps_vector_t m_removed_deps_{};
 };
 
 } // namespace sigma::detail_

--- a/include/sigma/eigen_compat.hpp
+++ b/include/sigma/eigen_compat.hpp
@@ -15,10 +15,10 @@ template<typename T>
 class Interval;
 } // namespace sigma
 
-/** @def EIGEN_NUMTRAITS(float_type)
+/** @def EIGEN_NUMTRAITS_UNCERTAIN(float_type)
  *  @brief Factorization for Eigen::NumTraits Specialization for Uncertain
  */
-#define EIGEN_NUMTRAITS(float_type)                                          \
+#define EIGEN_NUMTRAITS_UNCERTAIN(float_type)                                \
     /** @brief Numeric traits for Uncertain<float_type> */                   \
     template<>                                                               \
     struct NumTraits<sigma::Uncertain<float_type>> : NumTraits<float_type> { \
@@ -79,14 +79,14 @@ class Interval;
  */
 namespace Eigen {
 
-EIGEN_NUMTRAITS(float);
-EIGEN_NUMTRAITS(double);
+EIGEN_NUMTRAITS_UNCERTAIN(float);
+EIGEN_NUMTRAITS_UNCERTAIN(double);
 
 EIGEN_NUMTRAITS_INTERVAL(float);
 EIGEN_NUMTRAITS_INTERVAL(double);
 
 } // namespace Eigen
 
-#undef EIGEN_NUMTRAITS
+#undef EIGEN_NUMTRAITS_UNCERTAIN
 #undef EIGEN_NUMTRAITS_INTERVAL
 #endif // ENABLE_EIGEN_SUPPORT

--- a/include/sigma/operations/basic.ipp
+++ b/include/sigma/operations/basic.ipp
@@ -60,10 +60,12 @@ Uncertain<T> floor(const Uncertain<T>& a) {
 
 template<typename T>
 Uncertain<T> fmod(const Uncertain<T>& a, const Uncertain<T>& b) {
+    Uncertain<T> c(a);
     T mean = std::fmod(a.mean(), b.mean());
     T dcda = 1.0;
     T dcdb = -std::floor(a.mean() / b.mean());
-    return detail_::binary_result(a, b, mean, dcda, dcdb);
+    detail_::inplace_binary(c, b, mean, dcda, dcdb);
+    return c;
 }
 
 template<typename T>

--- a/include/sigma/operations/basic.ipp
+++ b/include/sigma/operations/basic.ipp
@@ -50,12 +50,12 @@ Uncertain<T> abs2(const Uncertain<T>& a) {
 
 template<typename T>
 Uncertain<T> ceil(const Uncertain<T>& a) {
-    return Uncertain<T>(std::ceil(a.mean()));
+    return Uncertain<T>(std::ceil(a.mean()), T{0.0}, a.threshold());
 }
 
 template<typename T>
 Uncertain<T> floor(const Uncertain<T>& a) {
-    return Uncertain<T>(std::floor(a.mean()));
+    return Uncertain<T>(std::floor(a.mean()), T{0.0}, a.threshold());
 }
 
 template<typename T>
@@ -102,12 +102,12 @@ U copysign(const U& a, const Uncertain<T>& b) {
 
 template<typename T>
 Uncertain<T> trunc(const Uncertain<T>& a) {
-    return Uncertain<T>(std::trunc(a.mean()));
+    return Uncertain<T>(std::trunc(a.mean()), T{0.0}, a.threshold());
 }
 
 template<typename T>
 Uncertain<T> round(const Uncertain<T>& a) {
-    return Uncertain<T>(std::round(a.mean()));
+    return Uncertain<T>(std::round(a.mean()), T{0.0}, a.threshold());
 }
 
 } // namespace sigma

--- a/include/sigma/operations/exponents.ipp
+++ b/include/sigma/operations/exponents.ipp
@@ -15,10 +15,12 @@ Uncertain<T> pow(const Uncertain<T>& a, const U& exp) {
 
 template<typename T>
 Uncertain<T> pow(const Uncertain<T>& a, const Uncertain<T>& exp) {
+    Uncertain<T> c(a);
     T mean = std::pow(a.mean(), exp.mean());
     T dcda = exp.mean() * std::pow(a.mean(), exp.mean() - 1);
     T dcdb = std::log(a.mean()) * std::pow(a.mean(), exp.mean());
-    return detail_::binary_result(a, exp, mean, dcda, dcdb);
+    detail_::inplace_binary(c, exp, mean, dcda, dcdb);
+    return c;
 }
 
 template<typename T>
@@ -86,10 +88,12 @@ Uncertain<T> log1p(const Uncertain<T>& a) {
 
 template<typename T>
 Uncertain<T> hypot(const Uncertain<T>& a, const Uncertain<T>& b) {
+    Uncertain<T> c(a);
     T mean = std::hypot(a.mean(), b.mean());
     T dcda = a.mean() / std::hypot(a.mean(), b.mean());
     T dcdb = b.mean() / std::hypot(a.mean(), b.mean());
-    return detail_::binary_result(a, b, mean, dcda, dcdb);
+    detail_::inplace_binary(c, b, mean, dcda, dcdb);
+    return c;
 }
 
 template<typename T, typename U>

--- a/include/sigma/operations/trigonometry.ipp
+++ b/include/sigma/operations/trigonometry.ipp
@@ -64,10 +64,12 @@ Uncertain<T> atan(const Uncertain<T>& a) {
 
 template<typename T>
 Uncertain<T> atan2(const Uncertain<T>& y, const Uncertain<T>& x) {
+    Uncertain<T> c(y);
     T mean = std::atan2(y.mean(), x.mean());
     T dcda = x.mean() / (std::pow(x.mean(), 2) + std::pow(y.mean(), 2));
     T dcdb = -y.mean() / (std::pow(x.mean(), 2) + std::pow(y.mean(), 2));
-    return detail_::binary_result(y, x, mean, dcda, dcdb);
+    detail_::inplace_binary(c, x, mean, dcda, dcdb);
+    return c;
 }
 
 template<typename T, typename U>

--- a/include/sigma/uncertain.hpp
+++ b/include/sigma/uncertain.hpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <memory>
 #include <type_traits>
+#include <typeinfo>
 #include <unordered_map>
 #include <utility>
 
@@ -47,20 +48,6 @@ public:
     /// A map of dependencies and their contributions to the uncertainty
     using deps_map_t = std::unordered_map<dep_sd_ptr, value_t>;
 
-    /// @brief Default ctor
-    Uncertain() noexcept = default;
-
-    /** @brief Construct an certain value from mean
-     *
-     *  The result of this is not an uncertain value. This is mostly a courtesy
-     *  function for simpler operation.
-     *
-     *  @param mean The value of the variable
-     *
-     *  @throw none No throw guarantee
-     */
-    Uncertain(value_t mean) : m_mean_(mean), m_sd_(0.0) {}
-
     /** @brief Construct an uncertain value from mean and standard deviation
      *
      *  Effectively, this creates a value that is a function of a single
@@ -68,10 +55,12 @@ public:
      *
      *  @param mean The average value of the variable
      *  @param sd The standard deviation of the variable
+     *  @param threshold The threshold for values to be considered zero
      *
      *  @throw none No throw guarantee
      */
-    Uncertain(value_t mean, value_t sd);
+    Uncertain(value_t mean = 0.0, value_t sd = 0.0,
+              value_t threshold = std::numeric_limits<value_t>::epsilon());
 
     /** @brief Get the mean value of the variable
      *
@@ -97,12 +86,31 @@ public:
      */
     const deps_map_t& deps() const { return m_deps_; }
 
+    /** @brief Access the zero threshold
+     *
+     *  @return The value of the zero threshold
+     *
+     *  @throw none No throw guarantee
+     */
+    value_t threshold() const { return m_threshold_; }
+
+    /** @brief Update the zero threshold
+     *
+     *  @param new_threshold The new value of the zero threshold
+     *
+     *  @throw none No throw guarantee
+     */
+    void threshold(value_t new_threshold) { m_threshold_ = new_threshold; }
+
 private:
     /// Mean value of the variable
     value_t m_mean_;
 
     /// Standard deviation of the variable
     value_t m_sd_;
+
+    /// Threshold for values to be considered zero
+    value_t m_threshold_;
 
     /** Map of the standard deviations this value is dependent on to their
      *  partial derivatives with respect to this value
@@ -120,9 +128,12 @@ private:
 // -- Out-of-line Definitions --------------------------------------------------
 
 template<typename ValueType>
-Uncertain<ValueType>::Uncertain(value_t mean, value_t sd) :
-  m_mean_(mean), m_sd_(std::abs(sd)) {
-    m_deps_.emplace(std::make_shared<dep_sd_t>(sd), value_t{1.0});
+Uncertain<ValueType>::Uncertain(value_t mean, value_t sd, value_t threshold) :
+  m_mean_(mean), m_sd_(std::abs(sd)), m_threshold_(threshold) {
+    if(m_sd_ < m_threshold_) { m_sd_ = 0.0; }
+    if(m_sd_ > 0.0) {
+        m_deps_.emplace(std::make_shared<dep_sd_t>(m_sd_), value_t{1.0});
+    }
 }
 
 // -- Utility functions --------------------------------------------------------
@@ -164,6 +175,7 @@ bool operator==(const Uncertain<ValueType1>& lhs,
         if(lhs.mean() != rhs.mean()) return false;
         if(lhs.sd() != rhs.sd()) return false;
         if(lhs.deps() != rhs.deps()) return false;
+        if(lhs.threshold() != rhs.threshold()) return false;
         return true;
     }
 }

--- a/include/sigma/uncertain.hpp
+++ b/include/sigma/uncertain.hpp
@@ -94,14 +94,6 @@ public:
      */
     value_t threshold() const { return m_threshold_; }
 
-    /** @brief Update the zero threshold
-     *
-     *  @param new_threshold The new value of the zero threshold
-     *
-     *  @throw none No throw guarantee
-     */
-    void threshold(value_t new_threshold) { m_threshold_ = new_threshold; }
-
 private:
     /// Mean value of the variable
     value_t m_mean_;
@@ -129,8 +121,9 @@ private:
 
 template<typename ValueType>
 Uncertain<ValueType>::Uncertain(value_t mean, value_t sd, value_t threshold) :
-  m_mean_(mean), m_sd_(std::abs(sd)), m_threshold_(threshold) {
-    if(m_sd_ < m_threshold_) { m_sd_ = 0.0; }
+  m_mean_(std::abs(mean) < threshold ? 0 : mean),
+  m_sd_(std::abs(sd) < threshold ? 0 : std::abs(sd)),
+  m_threshold_(threshold) {
     if(m_sd_ > 0.0) {
         m_deps_.emplace(std::make_shared<dep_sd_t>(m_sd_), value_t{1.0});
     }

--- a/tests/unit_tests/detail_/test_setter.cpp
+++ b/tests/unit_tests/detail_/test_setter.cpp
@@ -10,41 +10,95 @@ TEMPLATE_TEST_CASE("Setter", "", sigma::UFloat, sigma::UDouble) {
 
     uncertain_t a(3.0, 0.3);
     uncertain_t b(4.0, 0.4);
+    uncertain_t c(3.0, 0.3, 0.0);
+    uncertain_t d(5.0, 0.5, 0.01);
+    uncertain_t e(1.0, 0.001);
     testing_t testing_a(a);
     testing_t testing_b(b);
+    testing_t testing_c(c);
+    testing_t testing_d(d);
 
     SECTION("Update the mean") {
-        testing_a.update_mean(2.0);
-        test_uncertain(a, 2.0, 0.3, 1);
+        SECTION("Difference above threshold") {
+            testing_a.update_mean(2.0);
+            test_uncertain(a, 2.0, 0.3, 1);
+        }
+        SECTION("Difference below threshold") {
+            testing_d.update_mean(5.001);
+            test_uncertain(d, 5.0, 0.5, 1, 0.01);
+        }
     }
     SECTION("Update the derivatives") {
         SECTION("Only existing derivatives") {
-            testing_a.update_derivatives(2.0);
-            test_uncertain(a, 3.0, 0.6, 1);
+            SECTION("Derivative of one") {
+                testing_a.update_derivatives(1.0);
+                test_uncertain(a, 3.0, 0.3, 1);
+            }
+            SECTION("Derivative of zero") {
+                testing_c.update_derivatives(0.0);
+                test_uncertain(c, 3.0, 0.0, 0, 0.0);
+            }
+            SECTION("Derivative below threshold") {
+                testing_d.update_derivatives(0.001);
+                test_uncertain(d, 5.0, 0.0, 0, 0.01);
+            }
+            SECTION("Derivative of negative one") {
+                testing_a.update_derivatives(-1.0);
+                test_uncertain(a, 3.0, 0.3, 1);
+            }
+            SECTION("Derivative updated, no eliminations") {
+                testing_a.update_derivatives(2.0);
+                test_uncertain(a, 3.0, 0.6, 1);
+            }
+            SECTION("Derivative updated, resulting in eliminations") {
+                // Repeated updates to ensure we reduce the derivative below the
+                // threshold and eliminate the dependency from the map.
+                testing_d.update_derivatives(0.1);
+                testing_d.update_derivatives(0.1);
+                testing_d.update_derivatives(0.1);
+                test_uncertain(d, 5.0, 0.0, 0, 0.01);
+            }
         }
         SECTION("One list of derivatives") {
-            SECTION("Derivative of Zero") {
-                testing_a.update_derivatives(a.deps(), 0.0);
-                testing_a.update_derivatives(b.deps(), 0.0);
-                test_uncertain(a, 3.0, 0.3, 1);
+            SECTION("Derivative of zero") {
+                testing_c.update_derivatives(c.deps(), 0.0);
+                testing_c.update_derivatives(b.deps(), 0.0);
+                test_uncertain(c, 3.0, 0.3, 1, 0.0);
+            }
+            SECTION("Derivative below threshold") {
+                testing_d.update_derivatives(d.deps(), 0.001);
+                test_uncertain(d, 5.0, 0.5, 1, 0.01);
             }
             SECTION("Only pre-existing entries in map") {
                 testing_a.update_derivatives(a.deps(), 1.0);
                 test_uncertain(a, 3.0, 0.6, 1);
             }
+            SECTION("Pre-existing entries with eliminations") {
+                testing_d.update_derivatives(d.deps(), -1.001);
+                test_uncertain(d, 5.0, 0, 0, 0.01);
+            }
             SECTION("Pre-existing reduced to zero") {
-                testing_a.update_derivatives(a.deps(), -1.0);
-                test_uncertain(a, 3.0, 0.0, 0);
+                testing_c.update_derivatives(c.deps(), -1.0);
+                test_uncertain(c, 3.0, 0.0, 0, 0.0);
             }
             SECTION("Only new entries in map") {
                 testing_a.update_derivatives(b.deps(), 1.0);
                 test_uncertain(a, 3.0, 0.5, 2);
             }
+            SECTION("Only new entries below threshold") {
+                // Setup for b's map
+                testing_a.update_derivatives(0.001);
+                // Add to d
+                testing_d.update_derivatives(a.deps(), 1.0);
+                test_uncertain(d, 5.0, 0.5, 1, 0.01);
+                // testing_d.update_derivatives(e.deps(), 1.0);
+                // test_uncertain(d, 5.0, 0.5, 1, 0.01);
+            }
             SECTION("Pre-existing and new entries in map") {
                 // Setup for b's map
                 testing_b.update_derivatives(3.0);
                 testing_b.update_derivatives(a.deps(), 0.2 / 0.3);
-                // Add to derivatives to a
+                // Add to a
                 testing_a.update_derivatives(b.deps(), 1.0);
                 test_uncertain(a, 3.0, 1.3, 2);
             }

--- a/tests/unit_tests/operations/test_arithmetic.cpp
+++ b/tests/unit_tests/operations/test_arithmetic.cpp
@@ -6,65 +6,65 @@ using testing::test_uncertain;
 TEMPLATE_TEST_CASE("Arithmetic", "", sigma::UFloat, sigma::UDouble) {
     using testing_t = TestType;
 
-    auto a = testing_t(1.0, 0.1);
+    auto a = testing_t(1.0, 0.1, 0.001);
     auto b = testing_t(2.0, 0.2);
-    auto c = testing_t(3.0, 0.3);
 
     SECTION("Negation") {
-        test_uncertain(-a, -1.0, 0.1, 1);
-        test_uncertain(-(a + b), -3.0, 0.2236, 2);
-        test_uncertain(-a + a, 0.0, 0.0, 0);
+        test_uncertain(-a, -1.0, 0.1, 1, 0.001);
+        test_uncertain(-(a + b), -3.0, 0.2236, 2, 0.001);
+        test_uncertain(-a + a, 0.0, 0.0, 0, 0.001);
     }
     SECTION("Addition") {
-        SECTION("With Uncertain") { test_uncertain(a + b, 3.0, 0.2236, 2); }
+        SECTION("With Uncertain") {
+            test_uncertain(a + b, 3.0, 0.2236, 2, 0.001);
+        }
         SECTION("With Certain") {
-            test_uncertain(a + 1.0, 2.0, 0.1, 1);
-            test_uncertain(1.0 + a, 2.0, 0.1, 1);
+            test_uncertain(a + 1.0, 2.0, 0.1, 1, 0.001);
+            test_uncertain(1.0 + a, 2.0, 0.1, 1, 0.001);
         }
     }
     SECTION("Addition Assignment") {
         auto x = a;
         SECTION("With Uncertain") {
             x += b;
-            test_uncertain(x, 3.0, 0.2236, 2);
+            test_uncertain(x, 3.0, 0.2236, 2, 0.001);
         }
         SECTION("With Certain") {
             x += 1.0;
-            test_uncertain(x, 2.0, 0.1, 1);
+            test_uncertain(x, 2.0, 0.1, 1, 0.001);
         }
     }
     SECTION("Subtraction") {
         SECTION("With Uncertain") {
-            test_uncertain(a - b, -1.0, 0.2236, 2);
-            test_uncertain(a - a, 0.0, 0.0, 0);
+            test_uncertain(a - b, -1.0, 0.2236, 2, 0.001);
+            test_uncertain(a - a, 0.0, 0.0, 0, 0.001);
         }
         SECTION("With Certain") {
-            test_uncertain(a - 1.0, 0.0, 0.1, 1);
-            test_uncertain(2.0 - a, 1.0, 0.1, 1);
+            test_uncertain(a - 1.0, 0.0, 0.1, 1, 0.001);
+            test_uncertain(2.0 - a, 1.0, 0.1, 1, 0.001);
         }
     }
     SECTION("Subtraction Assignment") {
         auto x = a;
         SECTION("With Uncertain") {
             x -= b;
-            test_uncertain(x, -1.0, 0.2236, 2);
+            test_uncertain(x, -1.0, 0.2236, 2, 0.001);
         }
         SECTION("With Uncertain") {
             x -= 1.0;
-            test_uncertain(x, 0.0, 0.1, 1);
+            test_uncertain(x, 0.0, 0.1, 1, 0.001);
         }
     }
     SECTION("Multiplication") {
         SECTION("By Uncertain") {
-            auto x = a * b;
-            test_uncertain(a * b, 2.0, 0.2828, 2);
+            test_uncertain(a * b, 2.0, 0.2828, 2, 0.001);
         }
         SECTION("By Certain") {
             int two = 2;
             auto x  = a * two;        // Works with int
             auto y = (double)two * a; // Works with floating point, and reversed
-            test_uncertain(x, 2.0, 0.2, 1);
-            test_uncertain(y, 2.0, 0.2, 1);
+            test_uncertain(x, 2.0, 0.2, 1, 0.001);
+            test_uncertain(y, 2.0, 0.2, 1, 0.001);
             REQUIRE(x == y);
             REQUIRE(x == (a + a));
         }
@@ -73,7 +73,7 @@ TEMPLATE_TEST_CASE("Arithmetic", "", sigma::UFloat, sigma::UDouble) {
         SECTION("By Uncertain") {
             auto x = a;
             x *= b;
-            test_uncertain(x, 2.0, 0.2828, 2);
+            test_uncertain(x, 2.0, 0.2828, 2, 0.001);
         }
         SECTION("By Certain") {
             int two = 2;
@@ -81,23 +81,23 @@ TEMPLATE_TEST_CASE("Arithmetic", "", sigma::UFloat, sigma::UDouble) {
             auto y  = a;
             x *= two;
             y *= (double)two;
-            test_uncertain(x, 2.0, 0.2, 1);
-            test_uncertain(y, 2.0, 0.2, 1);
+            test_uncertain(x, 2.0, 0.2, 1, 0.001);
+            test_uncertain(y, 2.0, 0.2, 1, 0.001);
             REQUIRE(x == y);
             REQUIRE(x == (a + a));
         }
     }
     SECTION("Division") {
         SECTION("By Uncertain") {
-            test_uncertain(a / b, 0.5, 0.0707, 2);
-            test_uncertain(a / a, 1.0, 0.0, 0);
+            test_uncertain(a / b, 0.5, 0.0707, 2, 0.001);
+            test_uncertain(a / a, 1.0, 0.0, 0, 0.001);
         }
         SECTION("By Certain") {
             int two = 2;
             auto x  = a / two;        // Works with int
             auto y = (double)two / a; // Works with floating point, and reversed
-            test_uncertain(x, 0.5, 0.05, 1);
-            test_uncertain(y, 2.0, 0.2, 1);
+            test_uncertain(x, 0.5, 0.05, 1, 0.001);
+            test_uncertain(y, 2.0, 0.2, 1, 0.001);
         }
     }
     SECTION("Division Assignment") {
@@ -106,15 +106,15 @@ TEMPLATE_TEST_CASE("Arithmetic", "", sigma::UFloat, sigma::UDouble) {
             auto y = a;
             x /= b;
             y /= a;
-            test_uncertain(x, 0.5, 0.0707, 2);
-            test_uncertain(y, 1.0, 0.0, 0);
+            test_uncertain(x, 0.5, 0.0707, 2, 0.001);
+            test_uncertain(y, 1.0, 0.0, 0, 0.001);
         }
         SECTION("By Certain") {
             int two = 2;
             auto x  = a / two;        // Works with int
             auto y = (double)two / a; // Works with floating point, and reversed
-            test_uncertain(x, 0.5, 0.05, 1);
-            test_uncertain(y, 2.0, 0.2, 1);
+            test_uncertain(x, 0.5, 0.05, 1, 0.001);
+            test_uncertain(y, 2.0, 0.2, 1, 0.001);
         }
     }
 }

--- a/tests/unit_tests/operations/test_arithmetic.cpp
+++ b/tests/unit_tests/operations/test_arithmetic.cpp
@@ -22,6 +22,16 @@ TEMPLATE_TEST_CASE("Arithmetic", "", sigma::UFloat, sigma::UDouble) {
             test_uncertain(a + 1.0, 2.0, 0.1, 1, 0.001);
             test_uncertain(1.0 + a, 2.0, 0.1, 1, 0.001);
         }
+        SECTION("Ignores values below threshold") {
+            auto c = testing_t(10.0, 1.0, 1.0);
+            auto d = testing_t(0.1, 0.01);
+            // Updates mean, but ignores the derivative of d since it's below
+            // the threshold of c.
+            test_uncertain(c + a, 11.0, 1.0, 1, 1.0);
+            // Doesn't alter anything, because d is 0.0 +/- 0.0 within the
+            // threshold of c.
+            test_uncertain(c + d, 10.0, 1.0, 1, 1.0);
+        }
     }
     SECTION("Addition Assignment") {
         auto x = a;

--- a/tests/unit_tests/operations/test_basic.cpp
+++ b/tests/unit_tests/operations/test_basic.cpp
@@ -30,37 +30,37 @@ TEMPLATE_TEST_CASE("Basic (Interval)", "", sigma::IFloat, sigma::IDouble) {
 TEMPLATE_TEST_CASE("Basic", "", sigma::UFloat, sigma::UDouble) {
     using testing_t = TestType;
 
-    auto a = testing_t(1.0, 0.1);
-    auto b = testing_t(1.3, 0.1);
-    auto c = testing_t(2.0, 0.2);
-    auto d = testing_t(3.0, 0.3);
+    auto a = testing_t(1.0, 0.1, 0.001);
+    auto b = testing_t(1.3, 0.1, 0.002);
+    auto c = testing_t(2.0, 0.2, 0.003);
+    auto d = testing_t(3.0, 0.3, 0.004);
 
     SECTION("Copy sign") {
         REQUIRE(a == sigma::copysign(a, b));
         REQUIRE(-a == sigma::copysign(a, -b));
         REQUIRE(-a == sigma::copysign(a, -1.0));
         REQUIRE(-1.0 == sigma::copysign(1.0, -b));
-        test_uncertain(a + sigma::copysign(a, -1.0), 0.0, 0.0, 0);
+        test_uncertain(a + sigma::copysign(a, -1.0), 0.0, 0.0, 0, 0.001);
     }
     SECTION("Absolute Value") {
         REQUIRE(a == sigma::abs(-a));
         REQUIRE(a == sigma::fabs(-a));
     }
     SECTION("Absolute Value Squared") { REQUIRE((c * c) == sigma::abs2(-c)); }
-    SECTION("Ceiling") { test_uncertain(sigma::ceil(b), 2.0, 0.0, 0); }
-    SECTION("Floor") { test_uncertain(sigma::floor(b), 1.0, 0.0, 0); }
+    SECTION("Ceiling") { test_uncertain(sigma::ceil(b), 2.0, 0.0, 0, 0.002); }
+    SECTION("Floor") { test_uncertain(sigma::floor(b), 1.0, 0.0, 0, 0.002); }
     SECTION("Float modulo") {
-        test_uncertain(sigma::fmod(d, c), 1.0, 0.3606, 2);
-        test_uncertain(sigma::fmod(d, 2.0), 1.0, 0.3, 1);
-        test_uncertain(sigma::fmod(3.0, c), 1.0, 0.2, 1);
+        test_uncertain(sigma::fmod(d, c), 1.0, 0.3606, 2, 0.004);
+        test_uncertain(sigma::fmod(d, 2.0), 1.0, 0.3, 1, 0.004);
+        test_uncertain(sigma::fmod(3.0, c), 1.0, 0.2, 1, 0.003);
     }
     SECTION("Truncation") {
-        test_uncertain(sigma::trunc(b), 1.0, 0.0, 0);
-        test_uncertain(sigma::trunc(-b), -1.0, 0.0, 0);
+        test_uncertain(sigma::trunc(b), 1.0, 0.0, 0, 0.002);
+        test_uncertain(sigma::trunc(-b), -1.0, 0.0, 0, 0.002);
     }
     SECTION("Round") {
-        test_uncertain(sigma::round(b), 1.0, 0.0, 0);
-        test_uncertain(sigma::round(-b), -1.0, 0.0, 0);
+        test_uncertain(sigma::round(b), 1.0, 0.0, 0, 0.002);
+        test_uncertain(sigma::round(-b), -1.0, 0.0, 0, 0.002);
         test_uncertain(sigma::round(testing_t{0.5}), 1.0, 0.0, 0);
     }
 }

--- a/tests/unit_tests/operations/test_complex.cpp
+++ b/tests/unit_tests/operations/test_complex.cpp
@@ -12,7 +12,7 @@ TEMPLATE_TEST_CASE("Complex", "", sigma::UFloat, sigma::UDouble) {
         SECTION("Complex Conjugate") { REQUIRE(a == sigma::conj(a)); }
         SECTION("Real Part") { REQUIRE(a == sigma::real(a)); }
         SECTION("Imaginary Part") {
-            test_uncertain(sigma::imag(a), 0.0, 0.0, 1);
+            test_uncertain(sigma::imag(a), 0.0, 0.0, 0);
         }
     }
 }

--- a/tests/unit_tests/operations/test_error_and_gamma.cpp
+++ b/tests/unit_tests/operations/test_error_and_gamma.cpp
@@ -7,18 +7,18 @@ TEMPLATE_TEST_CASE("Error Function and Gamma", "", sigma::UFloat,
                    sigma::UDouble) {
     using testing_t = TestType;
 
-    auto a = testing_t(1.0, 0.1);
+    auto a = testing_t(1.0, 0.1, 0.001);
     SECTION("Error Function") {
-        test_uncertain(sigma::erf(a), 0.8427, 0.0415, 1);
+        test_uncertain(sigma::erf(a), 0.8427, 0.0415, 1, 0.001);
     }
     SECTION("Complementary Error Function") {
-        test_uncertain(sigma::erfc(a), 0.1573, 0.0415, 1);
-        test_uncertain(sigma::erf(a) + sigma::erfc(a), 1.0, 0.0, 0);
+        test_uncertain(sigma::erfc(a), 0.1573, 0.0415, 1, 0.001);
+        test_uncertain(sigma::erf(a) + sigma::erfc(a), 1.0, 0.0, 0, 0.001);
     }
     SECTION("Gamma Function") {
-        test_uncertain(sigma::tgamma(a), 1.0, 0.0577, 1);
+        test_uncertain(sigma::tgamma(a), 1.0, 0.0577, 1, 0.001);
     }
     SECTION("Gamma Function Natural Logarithm") {
-        test_uncertain(sigma::lgamma(a), 0.0, 0.0577, 1);
+        test_uncertain(sigma::lgamma(a), 0.0, 0.0577, 1, 0.001);
     }
 }

--- a/tests/unit_tests/operations/test_exponents.cpp
+++ b/tests/unit_tests/operations/test_exponents.cpp
@@ -37,67 +37,71 @@ TEMPLATE_TEST_CASE("Exponents (Interval)", "", sigma::IFloat, sigma::IDouble) {
 TEMPLATE_TEST_CASE("Exponents", "", sigma::UFloat, sigma::UDouble) {
     using testing_t = TestType;
 
-    auto a = testing_t(1.0, 0.1);
-    auto b = testing_t(2.0, 0.2);
-    auto c = testing_t(4.0, 0.4);
-    auto d = testing_t(5.0, 0.5);
-    auto e = testing_t(8.0, 0.8);
+    auto a = testing_t(1.0, 0.1, 0.001);
+    auto b = testing_t(2.0, 0.2, 0.002);
+    auto c = testing_t(4.0, 0.4, 0.003);
+    auto d = testing_t(5.0, 0.5, 0.004);
+    auto e = testing_t(8.0, 0.8, 0.005);
 
     SECTION("Exponentiation") {
         SECTION("Certain exponent") {
-            test_uncertain(sigma::pow(a, 2), 1.0, 0.2, 1);
-            test_uncertain(sigma::pow((a + b), -1), 0.3333, 0.0248, 2);
-            test_uncertain(sigma::pow((a + b + a * b), 0.5), 2.2361, 0.1118, 2);
-            test_uncertain(sigma::pow((a + b + a * b), 0.0), 1.0, 0.0, 0);
+            test_uncertain(sigma::pow(a, 2), 1.0, 0.2, 1, 0.001);
+            test_uncertain(sigma::pow((a + b), -1), 0.3333, 0.0248, 2, 0.001);
+            test_uncertain(sigma::pow((a + b + a * b), 0.5), 2.2361, 0.1118, 2,
+                           0.001);
+            test_uncertain(sigma::pow((a + b + a * b), 0.0), 1.0, 0.0, 0,
+                           0.001);
         }
         SECTION("Uncertain exponent") {
-            test_uncertain(sigma::pow(a, b), 1.0, 0.2, 1);
-            test_uncertain(sigma::pow(c, -b), 0.0625, 0.0214, 2);
-            test_uncertain(sigma::pow(c, a * 0.5), 2.0, 0.1709, 2);
+            test_uncertain(sigma::pow(a, b), 1.0, 0.2, 1, 0.001);
+            test_uncertain(sigma::pow(c, -b), 0.0625, 0.0214, 2, 0.003);
+            test_uncertain(sigma::pow(c, a * 0.5), 2.0, 0.1709, 2, 0.003);
         }
     }
     SECTION("Square Root") {
-        test_uncertain(sigma::sqrt(a), 1.0, 0.05, 1);
-        test_uncertain(sigma::sqrt(c), 2.0, 0.1, 1);
-        test_uncertain(sigma::sqrt(c + d), 3.0, 0.1067, 2);
+        test_uncertain(sigma::sqrt(a), 1.0, 0.05, 1, 0.001);
+        test_uncertain(sigma::sqrt(c), 2.0, 0.1, 1, 0.003);
+        test_uncertain(sigma::sqrt(c + d), 3.0, 0.1067, 2, 0.003);
     }
-    SECTION("Cube Root") { test_uncertain(sigma::cbrt(e), 2.0, 0.0667, 1); }
+    SECTION("Cube Root") {
+        test_uncertain(sigma::cbrt(e), 2.0, 0.0667, 1, 0.005);
+    }
     SECTION("Exponential Function") {
         SECTION("Natural Exponential") {
-            test_uncertain(sigma::exp(a), 2.7183, 0.2718, 1);
+            test_uncertain(sigma::exp(a), 2.7183, 0.2718, 1, 0.001);
         }
         SECTION("Exponential Base 2 Function") {
-            test_uncertain(sigma::exp2(a), 2.0, 0.1386, 1);
+            test_uncertain(sigma::exp2(a), 2.0, 0.1386, 1, 0.001);
         }
         SECTION("Exponential Minus 1 Function") {
-            test_uncertain(sigma::expm1(a), 1.7183, 0.2718, 1);
+            test_uncertain(sigma::expm1(a), 1.7183, 0.2718, 1, 0.001);
         }
     }
     SECTION("Logarithms") {
         SECTION("Natural Log") {
-            test_uncertain(sigma::log(a), 0.0, 0.1, 1);
-            test_uncertain(sigma::log(b), 0.6931, 0.1, 1);
+            test_uncertain(sigma::log(a), 0.0, 0.1, 1, 0.001);
+            test_uncertain(sigma::log(b), 0.6931, 0.1, 1, 0.002);
         }
         SECTION("Log Base 10") {
-            test_uncertain(sigma::log10(a), 0.0, 0.0434, 1);
-            test_uncertain(sigma::log10(b), 0.3010, 0.0434, 1);
+            test_uncertain(sigma::log10(a), 0.0, 0.0434, 1, 0.001);
+            test_uncertain(sigma::log10(b), 0.3010, 0.0434, 1, 0.002);
         }
         SECTION("Log Base 2") {
-            test_uncertain(sigma::log2(a), 0.0, 0.1443, 1);
-            test_uncertain(sigma::log2(b), 1.0, 0.1443, 1);
+            test_uncertain(sigma::log2(a), 0.0, 0.1443, 1, 0.001);
+            test_uncertain(sigma::log2(b), 1.0, 0.1443, 1, 0.002);
         }
         SECTION("Natural Log Plus 1") {
-            test_uncertain(sigma::log1p(a), 0.6931, 0.05, 1);
-            test_uncertain(sigma::log1p(b), 1.0986, 0.0667, 1);
+            test_uncertain(sigma::log1p(a), 0.6931, 0.05, 1, 0.001);
+            test_uncertain(sigma::log1p(b), 1.0986, 0.0667, 1, 0.002);
         }
     }
     SECTION("Hypotenuse") {
         SECTION("Two Uncertain Variables") {
-            test_uncertain(sigma::hypot(a, b), 2.2361, 0.1844, 2);
+            test_uncertain(sigma::hypot(a, b), 2.2361, 0.1844, 2, 0.001);
         }
         SECTION("One Uncertain Variable") {
-            test_uncertain(sigma::hypot(a, 2.0), 2.2361, 0.0447, 1);
-            test_uncertain(sigma::hypot(2.0, a), 2.2361, 0.0447, 1);
+            test_uncertain(sigma::hypot(a, 2.0), 2.2361, 0.0447, 1, 0.001);
+            test_uncertain(sigma::hypot(2.0, a), 2.2361, 0.0447, 1, 0.001);
         }
     }
 }

--- a/tests/unit_tests/operations/test_hyperbolic.cpp
+++ b/tests/unit_tests/operations/test_hyperbolic.cpp
@@ -6,16 +6,26 @@ using testing::test_uncertain;
 TEMPLATE_TEST_CASE("Hyperbolic", "", sigma::UFloat, sigma::UDouble) {
     using testing_t = TestType;
 
-    auto a = testing_t(0.785398, 0.1);
-    auto b = testing_t(1.0, 0.1);
-    auto c = testing_t(2.0, 0.2);
+    auto a = testing_t(0.785398, 0.1, 0.001);
+    auto b = testing_t(1.0, 0.1, 0.002);
+    auto c = testing_t(2.0, 0.2, 0.003);
 
-    SECTION("Sine") { test_uncertain(sigma::sinh(a), 0.8687, 0.1325, 1); }
-    SECTION("Cosine") { test_uncertain(sigma::cosh(a), 1.3246, 0.0869, 1); }
-    SECTION("Tangent") { test_uncertain(sigma::tanh(a), 0.6558, 0.0570, 1); }
-    SECTION("Arcsine") { test_uncertain(sigma::asinh(b), 0.8814, 0.0707, 1); }
-    SECTION("Arccosine") { test_uncertain(sigma::acosh(c), 1.3170, 0.1155, 1); }
+    SECTION("Sine") {
+        test_uncertain(sigma::sinh(a), 0.8687, 0.1325, 1, 0.001);
+    }
+    SECTION("Cosine") {
+        test_uncertain(sigma::cosh(a), 1.3246, 0.0869, 1, 0.001);
+    }
+    SECTION("Tangent") {
+        test_uncertain(sigma::tanh(a), 0.6558, 0.0570, 1, 0.001);
+    }
+    SECTION("Arcsine") {
+        test_uncertain(sigma::asinh(b), 0.8814, 0.0707, 1, 0.002);
+    }
+    SECTION("Arccosine") {
+        test_uncertain(sigma::acosh(c), 1.3170, 0.1155, 1, 0.003);
+    }
     SECTION("Arctangent") {
-        test_uncertain(sigma::atanh(a), 1.0593, 0.2610, 1);
+        test_uncertain(sigma::atanh(a), 1.0593, 0.2610, 1, 0.001);
     }
 }

--- a/tests/unit_tests/operations/test_trigonometry.cpp
+++ b/tests/unit_tests/operations/test_trigonometry.cpp
@@ -6,28 +6,40 @@ using testing::test_uncertain;
 TEMPLATE_TEST_CASE("Trigonometry", "", sigma::UFloat, sigma::UDouble) {
     using testing_t = TestType;
 
-    auto a = testing_t(0.785398, 0.1);
-    auto b = testing_t(45.0, 0.1);
-    auto c = testing_t(1.0, 0.1);
-    auto d = testing_t(2.0, 0.2);
+    auto a = testing_t(0.785398, 0.1, 0.001);
+    auto b = testing_t(45.0, 0.1, 0.002);
+    auto c = testing_t(1.0, 0.1, 0.003);
+    auto d = testing_t(2.0, 0.2, 0.004);
 
     SECTION("Degrees") {
-        test_uncertain(sigma::degrees(a), 45.0000, 5.7296, 1);
+        test_uncertain(sigma::degrees(a), 45.0000, 5.7296, 1, 0.001);
     }
-    SECTION("Radians") { test_uncertain(sigma::radians(b), 0.7854, 0.0017, 1); }
-    SECTION("Sine") { test_uncertain(sigma::sin(a), 0.7071, 0.0707, 1); }
-    SECTION("Cosine") { test_uncertain(sigma::cos(a), 0.7071, 0.0707, 1); }
-    SECTION("Tangent") { test_uncertain(sigma::tan(a), 1.0000, 0.2000, 1); }
-    SECTION("Arcsine") { test_uncertain(sigma::asin(a), 0.9033, 0.1616, 1); }
-    SECTION("Arccosine") { test_uncertain(sigma::acos(a), 0.6675, 0.1616, 1); }
-    SECTION("Arctangent") { test_uncertain(sigma::atan(a), 0.6658, 0.0618, 1); }
+    SECTION("Radians") {
+        test_uncertain(sigma::radians(b), 0.7854, 0.0017, 1, 0.002);
+    }
+    SECTION("Sine") { test_uncertain(sigma::sin(a), 0.7071, 0.0707, 1, 0.001); }
+    SECTION("Cosine") {
+        test_uncertain(sigma::cos(a), 0.7071, 0.0707, 1, 0.001);
+    }
+    SECTION("Tangent") {
+        test_uncertain(sigma::tan(a), 1.0000, 0.2000, 1, 0.001);
+    }
+    SECTION("Arcsine") {
+        test_uncertain(sigma::asin(a), 0.9033, 0.1616, 1, 0.001);
+    }
+    SECTION("Arccosine") {
+        test_uncertain(sigma::acos(a), 0.6675, 0.1616, 1, 0.001);
+    }
+    SECTION("Arctangent") {
+        test_uncertain(sigma::atan(a), 0.6658, 0.0618, 1, 0.001);
+    }
     SECTION("Two Argument Arctangent") {
         SECTION("Two Uncertain Variables") {
-            test_uncertain(sigma::atan2(c, d), 0.4636, 0.0566, 2);
+            test_uncertain(sigma::atan2(c, d), 0.4636, 0.0566, 2, 0.003);
         }
         SECTION("One Uncertain Variables") {
-            test_uncertain(sigma::atan2(c, 2.0), 0.4636, 0.0400, 1);
-            test_uncertain(sigma::atan2(1.0, d), 0.4636, 0.0400, 1);
+            test_uncertain(sigma::atan2(c, 2.0), 0.4636, 0.0400, 1, 0.003);
+            test_uncertain(sigma::atan2(1.0, d), 0.4636, 0.0400, 1, 0.004);
         }
     }
 }

--- a/tests/unit_tests/test_uncertain.cpp
+++ b/tests/unit_tests/test_uncertain.cpp
@@ -31,8 +31,12 @@ TEMPLATE_TEST_CASE("Uncertain", "", sigma::UFloat, sigma::UDouble) {
             test_uncertain(second, 1.0, 0.1, 1);
         }
         SECTION("With Mean, SD, and Threshold") {
-            auto value = testing_t(1.0, 0.1, 0.2);
-            test_uncertain(value, 1.0, 0.0, 0, 0.2);
+            auto value = testing_t(1.0, 0.1, 0.02);
+            test_uncertain(value, 1.0, 0.1, 1, 0.02);
+        }
+        SECTION("Mean and SD below threshold") {
+            auto value = testing_t(1.0, 0.1, 10.0);
+            test_uncertain(value, 0.0, 0.0, 0, 10.0);
         }
         SECTION("Copy") {
             auto first = testing_t(1.0, 0.1);
@@ -58,12 +62,6 @@ TEMPLATE_TEST_CASE("Uncertain", "", sigma::UFloat, sigma::UDouble) {
             test_uncertain(value, 1.0, 0.1, 1);
             test_uncertain(first, 1.0, 0.1, 0);
         }
-    }
-    SECTION("Update Zero Threshold") {
-        testing_t first;
-        value_t corr = 0.1;
-        first.threshold(corr);
-        REQUIRE(first.threshold() == corr);
     }
     SECTION("operator<<(std::ostream, IndependentVariable)") {
         value_t mean = 1.0, std = 0.1;

--- a/tests/unit_tests/test_uncertain.cpp
+++ b/tests/unit_tests/test_uncertain.cpp
@@ -9,18 +9,14 @@ TEMPLATE_TEST_CASE("Uncertain", "", sigma::UFloat, sigma::UDouble) {
     using value_t   = typename testing_t::value_t;
     using other_t   = typename testing::test_traits<TestType>::other_t;
 
-    auto default_threshold = std::numeric_limits<value_t>::epsilon();
-
     SECTION("Constructors") {
         SECTION("Default") {
             auto value = testing_t();
             test_uncertain(value, 0.0, 0.0, 0);
-            REQUIRE(value.threshold() == default_threshold);
         }
         SECTION("With Value") {
             auto value = testing_t(1.0);
             test_uncertain(value, 1.0, 0.0, 0);
-            REQUIRE(value.threshold() == default_threshold);
         }
         SECTION("With Mean and SD") {
             // Mix up the floating point types to check implicit conversions
@@ -32,41 +28,34 @@ TEMPLATE_TEST_CASE("Uncertain", "", sigma::UFloat, sigma::UDouble) {
             auto first  = testing_t(mean1, sd1);
             auto second = testing_t(mean2, sd2);
             test_uncertain(first, 1.0, 0.1, 1);
-            REQUIRE(first.threshold() == default_threshold);
             test_uncertain(second, 1.0, 0.1, 1);
-            REQUIRE(second.threshold() == default_threshold);
         }
         SECTION("With Mean, SD, and Threshold") {
             auto value = testing_t(1.0, 0.1, 0.2);
-            test_uncertain(value, 1.0, 0.0, 0);
-            REQUIRE(value.threshold() == value_t{0.2});
+            test_uncertain(value, 1.0, 0.0, 0, 0.2);
         }
         SECTION("Copy") {
             auto first = testing_t(1.0, 0.1);
             testing_t value(first);
             test_uncertain(value, 1.0, 0.1, 1);
-            REQUIRE(value.threshold() == default_threshold);
             test_uncertain(first, 1.0, 0.1, 1);
         }
         SECTION("Move") {
             auto first = testing_t(1.0, 0.1);
             testing_t value(std::move(first));
             test_uncertain(value, 1.0, 0.1, 1);
-            REQUIRE(value.threshold() == default_threshold);
             test_uncertain(first, 1.0, 0.1, 0);
         }
         SECTION("Copy Assignment") {
             auto first = testing_t(1.0, 0.1);
             auto value = first;
             test_uncertain(value, 1.0, 0.1, 1);
-            REQUIRE(value.threshold() == default_threshold);
             test_uncertain(first, 1.0, 0.1, 1);
         }
         SECTION("Move Assignment") {
             auto first = testing_t(1.0, 0.1);
             auto value = std::move(first);
             test_uncertain(value, 1.0, 0.1, 1);
-            REQUIRE(value.threshold() == default_threshold);
             test_uncertain(first, 1.0, 0.1, 0);
         }
     }

--- a/tests/unit_tests/test_uncertain.cpp
+++ b/tests/unit_tests/test_uncertain.cpp
@@ -9,14 +9,18 @@ TEMPLATE_TEST_CASE("Uncertain", "", sigma::UFloat, sigma::UDouble) {
     using value_t   = typename testing_t::value_t;
     using other_t   = typename testing::test_traits<TestType>::other_t;
 
+    auto default_threshold = std::numeric_limits<value_t>::epsilon();
+
     SECTION("Constructors") {
         SECTION("Default") {
             auto value = testing_t();
             test_uncertain(value, 0.0, 0.0, 0);
+            REQUIRE(value.threshold() == default_threshold);
         }
         SECTION("With Value") {
             auto value = testing_t(1.0);
             test_uncertain(value, 1.0, 0.0, 0);
+            REQUIRE(value.threshold() == default_threshold);
         }
         SECTION("With Mean and SD") {
             // Mix up the floating point types to check implicit conversions
@@ -28,32 +32,49 @@ TEMPLATE_TEST_CASE("Uncertain", "", sigma::UFloat, sigma::UDouble) {
             auto first  = testing_t(mean1, sd1);
             auto second = testing_t(mean2, sd2);
             test_uncertain(first, 1.0, 0.1, 1);
+            REQUIRE(first.threshold() == default_threshold);
             test_uncertain(second, 1.0, 0.1, 1);
+            REQUIRE(second.threshold() == default_threshold);
+        }
+        SECTION("With Mean, SD, and Threshold") {
+            auto value = testing_t(1.0, 0.1, 0.2);
+            test_uncertain(value, 1.0, 0.0, 0);
+            REQUIRE(value.threshold() == value_t{0.2});
         }
         SECTION("Copy") {
             auto first = testing_t(1.0, 0.1);
             testing_t value(first);
             test_uncertain(value, 1.0, 0.1, 1);
+            REQUIRE(value.threshold() == default_threshold);
             test_uncertain(first, 1.0, 0.1, 1);
         }
         SECTION("Move") {
             auto first = testing_t(1.0, 0.1);
             testing_t value(std::move(first));
             test_uncertain(value, 1.0, 0.1, 1);
+            REQUIRE(value.threshold() == default_threshold);
             test_uncertain(first, 1.0, 0.1, 0);
         }
         SECTION("Copy Assignment") {
             auto first = testing_t(1.0, 0.1);
             auto value = first;
             test_uncertain(value, 1.0, 0.1, 1);
+            REQUIRE(value.threshold() == default_threshold);
             test_uncertain(first, 1.0, 0.1, 1);
         }
         SECTION("Move Assignment") {
             auto first = testing_t(1.0, 0.1);
             auto value = std::move(first);
             test_uncertain(value, 1.0, 0.1, 1);
+            REQUIRE(value.threshold() == default_threshold);
             test_uncertain(first, 1.0, 0.1, 0);
         }
+    }
+    SECTION("Update Zero Threshold") {
+        testing_t first;
+        value_t corr = 0.1;
+        first.threshold(corr);
+        REQUIRE(first.threshold() == corr);
     }
     SECTION("operator<<(std::ostream, IndependentVariable)") {
         value_t mean = 1.0, std = 0.1;
@@ -80,6 +101,10 @@ TEMPLATE_TEST_CASE("Uncertain", "", sigma::UFloat, sigma::UDouble) {
         }
         SECTION("Different Standard Deviation") {
             auto second = testing_t(1.0, 0.2);
+            REQUIRE_FALSE(first == second);
+        }
+        SECTION("Different Threshold") {
+            auto second = testing_t(1.0, 0.1, 0.2);
             REQUIRE_FALSE(first == second);
         }
         SECTION("Different Dependencies") {

--- a/tests/unit_tests/testing.hpp
+++ b/tests/unit_tests/testing.hpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <sigma/sigma.hpp>
+#include <type_traits>
 
 namespace testing {
 
@@ -29,12 +30,19 @@ struct test_traits<sigma::IDouble> {
     using other_t = sigma::IFloat;
 };
 
+#define VALUE_TYPE typename std::remove_reference<TestType>::type::value_t
+
 template<typename TestType>
-void test_uncertain(TestType&& x, double m, double s, std::size_t n) {
+void test_uncertain(
+  TestType&& x, VALUE_TYPE m, VALUE_TYPE s, std::size_t n,
+  VALUE_TYPE threshold = std::numeric_limits<VALUE_TYPE>::epsilon()) {
     REQUIRE(x.mean() == Catch::Approx(m).margin(1.0e-4));
     REQUIRE(x.sd() == Catch::Approx(s).margin(1.0e-4));
     REQUIRE(x.deps().size() == n);
+    REQUIRE(x.threshold() == threshold);
 }
+
+#undef VALUE_TYPE
 
 template<typename TestType>
 void test_interval(TestType&& x, double lo, double hi) {


### PR DESCRIPTION
This PR adds a threshold value to instances of `sigma::uncertain` for determining when a value should be consider zero, defaulting to `std::numeric_limits<value_t>::epsilon()`. Each instance of `sigma::uncertain` maintains its own threshold, which is used to determine when contributions have been effectively reduced to zero and should be removed from the map of dependencies. The addition of new independent variables whose value or partial derivatives that are less than this threshold are also ignored. Similarly, changes to the mean value are ignored when the difference between the new and old value is less than this threshold. These changes are in an effort to minimize tracking dependencies whose contributions are effectively just noise.