### PR TITLE
Adds ThresholdedAffine Class

### DIFF
--- a/include/sigma/affine/affine.hpp
+++ b/include/sigma/affine/affine.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <memory>
+#include <atomic>
 #include <optional>
 #include <sigma/interval/interval.hpp>
 #include <sstream>
@@ -54,7 +54,7 @@ public:
     using value_t = ValueType;
 
     /// Opaque type used to store error term information
-    using error_term_t = std::shared_ptr<size_type>;
+    using error_term_t = size_type;
 
     /// Type used to map error terms to their radii
     using error_terms_t = std::unordered_map<error_term_t, value_t>;
@@ -747,17 +747,16 @@ public:
      */
     bool operator!=(const Affine& other) const { return !(*this == other); }
 
+    /// Returns a process-wide unique integer ID for a new error term symbol.
+    static error_term_t make_error_term() {
+        static std::atomic<size_type> s_next_id{0};
+        return s_next_id.fetch_add(1);
+    }
+
 private:
     /// Asserts that *this is not empty and throws domain_error if it is.
     void assert_not_empty_() const {
         if(empty()) { throw std::domain_error("Affine form is empty"); }
-    }
-
-    /// Creates an opaque object that uniquely identifies an error term.
-    /// At present it's the address of the object that is important;
-    // could switch to a hash or uuid.
-    error_term_t make_error_term() const {
-        return std::make_shared<size_type>(m_error_terms_.size());
     }
 
     /// This is the center of the affine form. If empty, m_center_ =

--- a/include/sigma/affine/eigen_compat.hpp
+++ b/include/sigma/affine/eigen_compat.hpp
@@ -44,6 +44,7 @@ class ThresholdedAffine;
             MulCost               = 3                                     \
         };                                                                \
     };                                                                    \
+    /** @brief Numeric traits for ThresholdedAffine<float_type> */        \
     template<>                                                            \
     struct NumTraits<sigma::ThresholdedAffine<float_type>>                \
       : NumTraits<float_type> {                                           \

--- a/include/sigma/affine/eigen_compat.hpp
+++ b/include/sigma/affine/eigen_compat.hpp
@@ -11,6 +11,10 @@
 namespace sigma {
 template<typename T>
 class Affine;
+
+template<typename T>
+class ThresholdedAffine;
+
 } // namespace sigma
 
 /** @def EIGEN_NUMTRAITS(float_type)
@@ -22,6 +26,29 @@ class Affine;
     struct NumTraits<sigma::Affine<float_type>> : NumTraits<float_type> { \
         /** The affine type */                                            \
         using Affine = sigma::Affine<float_type>;                         \
+        /** The corresponding real type */                                \
+        using Real = Affine;                                              \
+        /** The corresponding non-integer type */                         \
+        using NonInteger = Affine;                                        \
+        /** The corresponding literal type */                             \
+        using Literal = Affine;                                           \
+        /** The corresponding nested type */                              \
+        using Nested = Affine;                                            \
+        enum {                                                            \
+            IsComplex             = 0,                                    \
+            IsInteger             = 0,                                    \
+            IsSigned              = 1,                                    \
+            RequireInitialization = 1,                                    \
+            ReadCost              = 1,                                    \
+            AddCost               = 3,                                    \
+            MulCost               = 3                                     \
+        };                                                                \
+    };                                                                    \
+    template<>                                                            \
+    struct NumTraits<sigma::ThresholdedAffine<float_type>>                \
+      : NumTraits<float_type> {                                           \
+        /** The affine type */                                            \
+        using Affine = sigma::ThresholdedAffine<float_type>;              \
         /** The corresponding real type */                                \
         using Real = Affine;                                              \
         /** The corresponding non-integer type */                         \

--- a/include/sigma/affine/thresholded_affine.hpp
+++ b/include/sigma/affine/thresholded_affine.hpp
@@ -1,0 +1,619 @@
+#pragma once
+#include <cmath>
+#include <sigma/affine/affine.hpp>
+
+/** @file thresholded_affine.hpp
+ *  @brief Defines the ThresholdedAffine class
+ */
+
+namespace sigma {
+
+/** @brief Implements affine arithmetic with small-term lumping.
+ *
+ * @tparam ValueType The numeric type of the center and error term radii.
+ *
+ * ThresholdedAffine extends standard affine arithmetic with a mechanism to
+ * control the number of error symbols carried in an affine form. Each
+ * arithmetic operation can introduce new error symbols (e.g. multiplication
+ * creates a nonlinearity symbol); without pruning, the symbol count grows
+ * unboundedly.
+ *
+ * This class reduces symbol proliferation by collapsing small error terms into
+ * a single persistent "lump" symbol. After each operation, any error term
+ * whose relative contribution to the total radius falls below a user-specified
+ * threshold @f$t@f$ is folded into the lump:
+ * @f[
+ *   \frac{|x_i|}{\sum_j |x_j|} < t \implies x_i \text{ is lumped}
+ * @f]
+ *
+ * The resulting interval is always a superset of the interval that would be
+ * produced by an unthresholded Affine form, so the approach is conservative
+ * (sound). The only loss relative to full affine arithmetic is that small
+ * dependent error terms that would otherwise cancel may no longer cancel after
+ * lumping.
+ *
+ * Constructors accept a @ref Threshold tag type to distinguish the threshold
+ * parameter from ordinary value parameters and avoid constructor ambiguity.
+ */
+template<typename ValueType>
+class ThresholdedAffine {
+public:
+    /// Type used for indexing and offsets
+    using size_type = std::size_t;
+
+    /// Type used for storing floating point values
+    using value_t = ValueType;
+
+    /// Opaque type used to store error term information
+    using error_term_t = typename Affine<ValueType>::error_term_t;
+
+    /// Type used to map error terms to their radii
+    using error_terms_t = typename Affine<ValueType>::error_terms_t;
+
+    /// Type of an interval
+    using interval_t = typename Affine<ValueType>::interval_t;
+
+    /// Type of the underlying Affine form
+    using affine_t = Affine<ValueType>;
+
+    /** @brief Tag type used to pass the relative threshold to constructors.
+     *
+     *  Wrapping the threshold in this type avoids overload ambiguity between
+     *  `ThresholdedAffine(value_t lo, value_t hi)` and
+     *  `ThresholdedAffine(value_t center, value_t threshold)`.
+     *
+     *  Example:
+     *  @code
+     *  ThresholdedAffine<double> x(1.0, 2.0, Threshold{0.05});
+     *  @endcode
+     */
+    struct Threshold {
+        value_t value;
+        explicit Threshold(value_t v) : value(v) {}
+    };
+
+    // --- Constructors and Assignment ----------------------------------------
+
+    /** @brief Constructs an empty ThresholdedAffine.
+     *
+     *  @throw none No throw guarantee
+     */
+    ThresholdedAffine() :
+      m_lump_term_(std::make_shared<size_type>(0)),
+      m_threshold_(value_t(0.01)) {}
+
+    /** @brief Constructs a ThresholdedAffine from a center value.
+     *
+     *  @param[in] center The center value.
+     *  @param[in] t      The relative threshold (default 1%).
+     *
+     *  @throw none No throw guarantee
+     */
+    explicit ThresholdedAffine(value_t center,
+                               Threshold t = Threshold{value_t(0.01)}) :
+      m_affine_(center),
+      m_lump_term_(std::make_shared<size_type>(0)),
+      m_threshold_(t.value) {
+        apply_threshold_();
+    }
+
+    /** @brief Constructs a ThresholdedAffine from a lower and upper bound.
+     *
+     *  @param[in] lo The lower bound.
+     *  @param[in] hi The upper bound.
+     *  @param[in] t  The relative threshold (default 1%).
+     *
+     *  @throw std::bad_alloc If memory allocation for the error term fails.
+     */
+    ThresholdedAffine(value_t lo, value_t hi,
+                      Threshold t = Threshold{value_t(0.01)}) :
+      m_affine_(lo, hi),
+      m_lump_term_(std::make_shared<size_type>(0)),
+      m_threshold_(t.value) {
+        apply_threshold_();
+    }
+
+    /** @brief Constructs a ThresholdedAffine from an interval.
+     *
+     *  @param[in] interval The interval.
+     *  @param[in] t        The relative threshold (default 1%).
+     *
+     *  @throw std::bad_alloc If memory allocation for the error term fails.
+     */
+    explicit ThresholdedAffine(const interval_t& interval,
+                               Threshold t = Threshold{value_t(0.01)}) :
+      m_affine_(interval),
+      m_lump_term_(std::make_shared<size_type>(0)),
+      m_threshold_(t.value) {
+        apply_threshold_();
+    }
+
+    /** @brief Constructs a ThresholdedAffine from a center and error terms.
+     *
+     *  @param[in] center The center value.
+     *  @param[in] radii  Map of error symbols to their radii.
+     *  @param[in] t      The relative threshold (default 1%).
+     *
+     *  @throw none No throw guarantee
+     */
+    ThresholdedAffine(value_t center, error_terms_t radii,
+                      Threshold t = Threshold{value_t(0.01)}) :
+      m_affine_(center, std::move(radii)),
+      m_lump_term_(std::make_shared<size_type>(0)),
+      m_threshold_(t.value) {
+        apply_threshold_();
+    }
+
+    /** @brief Constructs a ThresholdedAffine by wrapping an Affine form.
+     *
+     *  Used internally by operations that produce an Affine result and need to
+     *  re-wrap it as a ThresholdedAffine.
+     *
+     *  @param[in] a         The Affine form to wrap.
+     *  @param[in] threshold The relative threshold.
+     *
+     *  @throw std::bad_alloc If memory allocation for the lump term fails.
+     */
+    ThresholdedAffine(affine_t a, value_t threshold) :
+      m_affine_(std::move(a)),
+      m_lump_term_(std::make_shared<size_type>(0)),
+      m_threshold_(threshold) {
+        apply_threshold_();
+    }
+
+    ThresholdedAffine(const ThresholdedAffine&)                = default;
+    ThresholdedAffine(ThresholdedAffine&&) noexcept            = default;
+    ThresholdedAffine& operator=(const ThresholdedAffine&)     = default;
+    ThresholdedAffine& operator=(ThresholdedAffine&&) noexcept = default;
+
+    // -- State Accessors -----------------------------------------------------
+
+    /** @brief Returns the interval represented by *this.
+     *
+     *  @return The interval [center - radius, center + radius].
+     *  @throw none No throw guarantee
+     */
+    interval_t range() const { return m_affine_.range(); }
+
+    /** @brief Returns the center of the affine form.
+     *
+     *  @return The center value.
+     *  @throw std::domain_error If *this is empty.
+     */
+    value_t center() const { return m_affine_.center(); }
+
+    /** @brief Returns the error terms, including the lump term.
+     *
+     *  @return Const reference to the error terms map.
+     *  @throw None No throw guarantee.
+     */
+    const error_terms_t& error_terms() const { return m_affine_.error_terms(); }
+
+    /** @brief Returns the sum of absolute values of all error term radii.
+     *
+     *  @return The radius.
+     *  @throw std::domain_error If *this is empty.
+     */
+    value_t radius() const { return m_affine_.radius(); }
+
+    /** @brief Sets the center of the affine form.
+     *
+     *  @param[in] c The new center.
+     *  @throw None No throw guarantee.
+     */
+    void set_center(value_t c) { m_affine_.set_center(c); }
+
+    /** @brief Adds an error term to the affine form and applies thresholding.
+     *
+     *  @param[in] error_term The error symbol.
+     *  @param[in] r          The radius of the new term.
+     *  @throw None No throw guarantee.
+     */
+    void add_error_term(error_term_t error_term, value_t r) {
+        m_affine_.add_error_term(error_term, r);
+        apply_threshold_();
+    }
+
+    /** @brief Returns whether *this contains a scalar value.
+     *
+     *  @param[in] v The value to test.
+     *  @return True if the value is in range().
+     *  @throw none No throw guarantee
+     */
+    bool contains(value_t v) const { return m_affine_.contains(v); }
+
+    /** @brief Returns whether *this contains an interval.
+     *
+     *  @param[in] i The interval to test.
+     *  @return True if every point in @p i is in range().
+     *  @throw none No throw guarantee
+     */
+    bool contains(const interval_t& i) const { return m_affine_.contains(i); }
+
+    /** @brief Returns whether *this contains another ThresholdedAffine's range.
+     *
+     *  @param[in] other The ThresholdedAffine to test.
+     *  @return True if every point in other.range() is in range().
+     *  @throw none No throw guarantee
+     */
+    bool contains(const ThresholdedAffine& other) const {
+        return m_affine_.contains(other.m_affine_.range());
+    }
+
+    /** @brief Returns whether *this is empty.
+     *
+     *  @return True if *this represents the empty set.
+     *  @throw none No throw guarantee
+     */
+    bool empty() const noexcept { return m_affine_.empty(); }
+
+    /** @brief Returns a string of the affine form.
+     *
+     *  @return Affine form string.
+     *  @throw std::bad_alloc
+     */
+    std::string print_affine_form() const {
+        return m_affine_.print_affine_form();
+    }
+
+    /** @brief Returns a string of the interval form.
+     *
+     *  @return Interval form string, e.g. [lo, hi].
+     *  @throw std::bad_alloc
+     */
+    std::string print_interval_form() const {
+        return m_affine_.print_interval_form();
+    }
+
+    /** @brief Returns the underlying Affine form (read-only).
+     *
+     *  Used by operations that need to call Affine-specific functions (e.g.
+     *  apply_affine_transform) and then re-wrap the result.
+     *
+     *  @return Const reference to the internal Affine form.
+     *  @throw none No throw guarantee
+     */
+    const affine_t& affine() const { return m_affine_; }
+
+    /** @brief Returns the relative threshold.
+     *
+     *  @return The threshold @f$t@f$ such that terms with
+     *          @f$|x_i|/\text{radius} < t@f$ are lumped.
+     *  @throw none No throw guarantee
+     */
+    value_t threshold() const { return m_threshold_; }
+
+    /** @brief Returns the lump error symbol.
+     *
+     *  @return The shared error_term_t used for lumped small contributions.
+     *  @throw none No throw guarantee
+     */
+    error_term_t lump_term() const { return m_lump_term_; }
+
+    // -- Arithmetic Operators ------------------------------------------------
+
+    /** @brief Returns the additive inverse of *this.
+     *
+     *  Negation preserves relative error-term magnitudes, so no re-thresholding
+     *  is needed.
+     *
+     *  @return The negated ThresholdedAffine.
+     *  @throw std::bad_alloc If memory allocation fails.
+     */
+    ThresholdedAffine operator-() const {
+        auto result      = *this;
+        result.m_affine_ = -m_affine_;
+        return result;
+    }
+
+    /** @brief Adds a scalar to *this.
+     *
+     *  @param[in] value The scalar to add.
+     *  @return Reference to *this.
+     *  @throw None No throw guarantee.
+     */
+    ThresholdedAffine& operator+=(value_t value) {
+        m_affine_ += value;
+        return *this;
+    }
+
+    /** @brief Adds another ThresholdedAffine to *this.
+     *
+     *  @param[in] other The form to add.
+     *  @return Reference to *this.
+     *  @throw None No throw guarantee.
+     */
+    ThresholdedAffine& operator+=(const ThresholdedAffine& other) {
+        m_affine_ += other.m_affine_;
+        apply_threshold_();
+        return *this;
+    }
+
+    ThresholdedAffine operator+(value_t value) const {
+        return ThresholdedAffine(*this) += value;
+    }
+
+    ThresholdedAffine operator+(const ThresholdedAffine& other) const {
+        return ThresholdedAffine(*this) += other;
+    }
+
+    /** @brief Subtracts a scalar from *this.
+     *
+     *  @param[in] value The scalar to subtract.
+     *  @return Reference to *this.
+     *  @throw None No throw guarantee.
+     */
+    ThresholdedAffine& operator-=(value_t value) {
+        m_affine_ -= value;
+        return *this;
+    }
+
+    /** @brief Subtracts another ThresholdedAffine from *this.
+     *
+     *  @param[in] other The form to subtract.
+     *  @return Reference to *this.
+     *  @throw None No throw guarantee.
+     */
+    ThresholdedAffine& operator-=(const ThresholdedAffine& other) {
+        m_affine_ -= other.m_affine_;
+        apply_threshold_();
+        return *this;
+    }
+
+    ThresholdedAffine operator-(value_t value) const {
+        return ThresholdedAffine(*this) -= value;
+    }
+
+    ThresholdedAffine operator-(const ThresholdedAffine& other) const {
+        return ThresholdedAffine(*this) -= other;
+    }
+
+    /** @brief Multiplies *this by a scalar.
+     *
+     *  @param[in] value The scalar to multiply by.
+     *  @return Reference to *this.
+     *  @throw None No throw guarantee.
+     */
+    ThresholdedAffine& operator*=(value_t value) {
+        m_affine_ *= value;
+        apply_threshold_();
+        return *this;
+    }
+
+    /** @brief Multiplies *this by another ThresholdedAffine.
+     *
+     *  Multiplication introduces a new nonlinearity error term; thresholding
+     *  is applied afterward so that small terms (including the new one, if its
+     *  relative contribution is negligible) are folded into the lump.
+     *
+     *  @param[in] other The form to multiply by.
+     *  @return Reference to *this.
+     *  @throw None No throw guarantee.
+     */
+    ThresholdedAffine& operator*=(const ThresholdedAffine& other) {
+        m_affine_ *= other.m_affine_;
+        apply_threshold_();
+        return *this;
+    }
+
+    ThresholdedAffine operator*(value_t value) const {
+        return ThresholdedAffine(*this) *= value;
+    }
+
+    ThresholdedAffine operator*(const ThresholdedAffine& other) const {
+        return ThresholdedAffine(*this) *= other;
+    }
+
+    /** @brief Divides *this by a scalar.
+     *
+     *  @param[in] value The scalar to divide by.
+     *  @return Reference to *this.
+     *  @throw std::domain_error If @p value is zero.
+     */
+    ThresholdedAffine& operator/=(value_t value) {
+        m_affine_ /= value;
+        apply_threshold_();
+        return *this;
+    }
+
+    /** @brief Divides *this by another ThresholdedAffine.
+     *
+     *  @param[in] other The form to divide by.
+     *  @return Reference to *this.
+     *  @throw std::domain_error If @p other is empty or contains zero.
+     */
+    ThresholdedAffine& operator/=(const ThresholdedAffine& other) {
+        m_affine_ /= other.m_affine_;
+        apply_threshold_();
+        return *this;
+    }
+
+    ThresholdedAffine operator/(value_t value) const {
+        return ThresholdedAffine(*this) /= value;
+    }
+
+    ThresholdedAffine operator/(const ThresholdedAffine& other) const {
+        return ThresholdedAffine(*this) /= other;
+    }
+
+    // -- Comparison Operators ------------------------------------------------
+
+    /** @brief Checks equality of two ThresholdedAffine forms.
+     *
+     *  Two ThresholdedAffine forms are equal if they have the same internal
+     *  Affine form and the same threshold.
+     *
+     *  @param[in] other The form to compare.
+     *  @return True if equal.
+     *  @throw none No throw guarantee.
+     */
+    bool operator==(const ThresholdedAffine& other) const {
+        return m_affine_ == other.m_affine_ &&
+               m_threshold_ == other.m_threshold_;
+    }
+
+    /** @brief Checks inequality of two ThresholdedAffine forms.
+     *
+     *  @param[in] other The form to compare.
+     *  @return True if not equal.
+     *  @throw none No throw guarantee.
+     */
+    bool operator!=(const ThresholdedAffine& other) const {
+        return !(*this == other);
+    }
+
+private:
+    /** @brief Collapses error terms whose relative contribution is below the
+     *         threshold into the persistent lump symbol.
+     *
+     *  After each arithmetic operation, scans all non-lump error terms. Terms
+     *  with @f$|x_i| / \text{total\_radius} < t@f$ are removed and their
+     *  absolute coefficient is added to the lump term's magnitude.
+     */
+    void apply_threshold_() {
+        if(m_affine_.empty()) return;
+        auto total_r = m_affine_.radius();
+        if(total_r == value_t(0)) return;
+
+        // Work on a snapshot to avoid modifying while iterating
+        auto terms = m_affine_.error_terms();
+
+        value_t lump_delta          = value_t(0);
+        value_t existing_lump_coeff = value_t(0);
+        error_terms_t new_terms;
+
+        for(auto&& [sym, coeff] : terms) {
+            if(sym == m_lump_term_) {
+                existing_lump_coeff = coeff;
+                continue;
+            }
+            if(std::fabs(coeff) / total_r < m_threshold_) {
+                lump_delta += std::fabs(coeff);
+            } else {
+                new_terms[sym] = coeff;
+            }
+        }
+
+        if(lump_delta > value_t(0) || existing_lump_coeff != value_t(0)) {
+            // Increase |existing_lump_coeff| by lump_delta, preserving sign.
+            // This ensures that if the lump was negated (e.g. via operator-),
+            // cancellation still works when equal forms are subtracted.
+            if(existing_lump_coeff >= value_t(0)) {
+                new_terms[m_lump_term_] = existing_lump_coeff + lump_delta;
+            } else {
+                new_terms[m_lump_term_] = existing_lump_coeff - lump_delta;
+            }
+        }
+
+        m_affine_ = affine_t(m_affine_.center(), std::move(new_terms));
+    }
+
+    /// The internal affine form holding all error terms (including lump).
+    affine_t m_affine_;
+
+    /// Persistent error symbol for aggregated small terms.
+    error_term_t m_lump_term_;
+
+    /// Relative threshold: terms with |x_i| / radius < m_threshold_ are lumped.
+    value_t m_threshold_;
+};
+
+// -- Non-member functions ----------------------------------------------------
+
+/** @brief Outputs the range of a ThresholdedAffine to a stream.
+ *
+ *  @related ThresholdedAffine
+ *  @tparam ValueType The value type.
+ */
+template<typename ValueType>
+std::ostream& operator<<(std::ostream& os,
+                         const ThresholdedAffine<ValueType>& a) {
+    os << a.range();
+    return os;
+}
+
+/** @brief Multiplies a scalar by a ThresholdedAffine.
+ *
+ *  @related ThresholdedAffine
+ *  @tparam ValueType The value type.
+ */
+template<typename ValueType>
+ThresholdedAffine<ValueType> operator*(ValueType value,
+                                       const ThresholdedAffine<ValueType>& a) {
+    return a * value;
+}
+
+// -- Operations --------------------------------------------------------------
+// These delegate to the corresponding Affine operations and re-wrap the result.
+
+/** @brief Absolute value of a ThresholdedAffine.
+ *
+ *  @related ThresholdedAffine
+ *  @tparam T The value type.
+ */
+template<typename T>
+ThresholdedAffine<T> abs(const ThresholdedAffine<T>& a) {
+    return ThresholdedAffine<T>(abs(a.affine()), a.threshold());
+}
+
+/** @brief Absolute value of a ThresholdedAffine (alias for abs).
+ *
+ *  @related ThresholdedAffine
+ *  @tparam T The value type.
+ */
+template<typename T>
+ThresholdedAffine<T> fabs(const ThresholdedAffine<T>& a) {
+    return ThresholdedAffine<T>(fabs(a.affine()), a.threshold());
+}
+
+/** @brief Square root of a ThresholdedAffine.
+ *
+ *  @related ThresholdedAffine
+ *  @tparam T The value type.
+ *  @throw std::domain_error If the range contains negative values.
+ */
+template<typename T>
+ThresholdedAffine<T> sqrt(const ThresholdedAffine<T>& a) {
+    return ThresholdedAffine<T>(sqrt(a.affine()), a.threshold());
+}
+
+/** @brief Exponential of a ThresholdedAffine.
+ *
+ *  @related ThresholdedAffine
+ *  @tparam T The value type.
+ */
+template<typename T>
+ThresholdedAffine<T> exp(const ThresholdedAffine<T>& a) {
+    return ThresholdedAffine<T>(exp(a.affine()), a.threshold());
+}
+
+/** @brief Natural logarithm of a ThresholdedAffine.
+ *
+ *  @related ThresholdedAffine
+ *  @tparam T The value type.
+ *  @throw std::domain_error If the range contains non-positive values.
+ */
+template<typename T>
+ThresholdedAffine<T> log(const ThresholdedAffine<T>& a) {
+    return ThresholdedAffine<T>(log(a.affine()), a.threshold());
+}
+
+/** @brief Power of a ThresholdedAffine.
+ *
+ *  @related ThresholdedAffine
+ *  @tparam T The value type.
+ *  @tparam U The exponent type.
+ *  @throw std::domain_error See Affine::pow for conditions.
+ */
+template<typename T, typename U>
+ThresholdedAffine<T> pow(const ThresholdedAffine<T>& a, const U& exp) {
+    return ThresholdedAffine<T>(pow(a.affine(), exp), a.threshold());
+}
+
+/// Typedef for a thresholded affine form of floats
+using TAFloat = ThresholdedAffine<float>;
+
+/// Typedef for a thresholded affine form of doubles
+using TADouble = ThresholdedAffine<double>;
+
+} // namespace sigma

--- a/include/sigma/affine/thresholded_affine.hpp
+++ b/include/sigma/affine/thresholded_affine.hpp
@@ -14,7 +14,7 @@ namespace sigma {
  *
  * ThresholdedAffine extends standard affine arithmetic with a mechanism to
  * control the number of error symbols carried in an affine form. Each
- * arithmetic operation can introduce new error symbols (e.g. multiplication
+ * non-affine operation can introduce new error symbols (e.g. multiplication
  * creates a nonlinearity symbol); without pruning, the symbol count grows
  * unboundedly.
  *
@@ -68,7 +68,9 @@ public:
      *  @endcode
      */
     struct Threshold {
+        /// The relative threshold value (e.g. 0.01 for 1%)
         value_t value;
+        /// Constructs a Threshold with the given value.
         explicit Threshold(value_t v) : value(v) {}
     };
 
@@ -76,51 +78,53 @@ public:
 
     /** @brief Constructs an empty ThresholdedAffine.
      *
+     *  The resulting ThresholdedAffine represents the empty set. The lump term
+     *  is initialized but has zero radius, and the threshold is set to the
+     *  default value.
+     *
      *  @throw none No throw guarantee
      */
     ThresholdedAffine() :
-      m_lump_term_(affine_t::make_error_term()), m_threshold_(value_t(0.01)) {}
+      m_lump_term_(affine_t::make_error_term()),
+      m_threshold_(default_threshold().value) {}
 
     /** @brief Constructs a ThresholdedAffine from a center value.
      *
      *  @param[in] center The center value.
-     *  @param[in] t      The relative threshold (default 1%).
+     *  @param[in] t      The relative threshold, defaults to
+     *                    default_threshold().
      *
      *  @throw none No throw guarantee
      */
     explicit ThresholdedAffine(value_t center,
-                               Threshold t = Threshold{value_t(0.01)}) :
-      m_affine_(center),
-      m_lump_term_(affine_t::make_error_term()),
-      m_threshold_(t.value) {
-        apply_threshold_();
-    }
+                               Threshold t = default_threshold()) :
+      ThresholdedAffine(interval_t(center), t) {}
 
     /** @brief Constructs a ThresholdedAffine from a lower and upper bound.
      *
      *  @param[in] lo The lower bound.
      *  @param[in] hi The upper bound.
-     *  @param[in] t  The relative threshold (default 1%).
+     *  @param[in] t  The relative threshold, defaults to
+     *                default_threshold().
      *
      *  @throw std::bad_alloc If memory allocation for the error term fails.
      */
     ThresholdedAffine(value_t lo, value_t hi,
-                      Threshold t = Threshold{value_t(0.01)}) :
-      m_affine_(lo, hi),
-      m_lump_term_(affine_t::make_error_term()),
-      m_threshold_(t.value) {
+                      Threshold t = default_threshold()) :
+      ThresholdedAffine(interval_t(lo, hi), t) {
         apply_threshold_();
     }
 
     /** @brief Constructs a ThresholdedAffine from an interval.
      *
      *  @param[in] interval The interval.
-     *  @param[in] t        The relative threshold (default 1%).
+     *  @param[in] t        The relative threshold, defaults to
+     *                      default_threshold().
      *
      *  @throw std::bad_alloc If memory allocation for the error term fails.
      */
     explicit ThresholdedAffine(const interval_t& interval,
-                               Threshold t = Threshold{value_t(0.01)}) :
+                               Threshold t = default_threshold()) :
       m_affine_(interval),
       m_lump_term_(affine_t::make_error_term()),
       m_threshold_(t.value) {
@@ -131,12 +135,13 @@ public:
      *
      *  @param[in] center The center value.
      *  @param[in] radii  Map of error symbols to their radii.
-     *  @param[in] t      The relative threshold (default 1%).
+     *  @param[in] t      The relative threshold, defaults to
+     *                    default_threshold().
      *
      *  @throw none No throw guarantee
      */
     ThresholdedAffine(value_t center, error_terms_t radii,
-                      Threshold t = Threshold{value_t(0.01)}) :
+                      Threshold t = default_threshold()) :
       m_affine_(center, std::move(radii)),
       m_lump_term_(affine_t::make_error_term()),
       m_threshold_(t.value) {
@@ -151,7 +156,8 @@ public:
      *  @param[in] a         The Affine form to wrap.
      *  @param[in] threshold The relative threshold.
      *
-     *  @throw std::bad_alloc If memory allocation for the lump term fails.
+     *  @throw std::bad_alloc If memory allocation for the error term fails.
+     *                        Strong throw guarantee.
      */
     ThresholdedAffine(affine_t a, value_t threshold) :
       m_affine_(std::move(a)),
@@ -160,12 +166,55 @@ public:
         apply_threshold_();
     }
 
-    ThresholdedAffine(const ThresholdedAffine&)                = default;
-    ThresholdedAffine(ThresholdedAffine&&) noexcept            = default;
-    ThresholdedAffine& operator=(const ThresholdedAffine&)     = default;
+    /** @brief Copy constructor.
+     *
+     *  @param[in] other The ThresholdedAffine to copy.
+     *
+     *  @throw std::bad_alloc If memory allocation for the error terms fails.
+     *                        Strong throw guarantee.
+     */
+    ThresholdedAffine(const ThresholdedAffine&) = default;
+
+    /** @brief Move constructor.
+     *
+     *  @param[in] other The ThresholdedAffine to move.
+     *  @throw none No throw guarantee
+     */
+    ThresholdedAffine(ThresholdedAffine&&) noexcept = default;
+
+    /** @brief Copy assignment operator.
+     *
+     *  @param[in] other The ThresholdedAffine to copy.
+     *
+     *  @return Reference to this ThresholdedAffine after assignment.
+     *
+     *  @throw std::bad_alloc If memory allocation for the error terms fails.
+     *                        Strong throw guarantee.
+     */
+    ThresholdedAffine& operator=(const ThresholdedAffine&) = default;
+
+    /** @brief Move assignment operator.
+     *
+     *  @param[in] other The ThresholdedAffine to move.
+     *
+     *  @return Reference to this ThresholdedAffine after assignment.
+     *
+     *  @throw none No throw guarantee
+     */
     ThresholdedAffine& operator=(ThresholdedAffine&&) noexcept = default;
 
     // -- State Accessors -----------------------------------------------------
+
+    /** @brief Returns the default threshold value.
+     *
+     *  This is a state method that ensures the default threshold is defined
+     *  in a single place and can be easily changed if needed. The default
+     *  threshold is currently set to 0.01 (1%).
+     *
+     *  @return The default threshold.
+     *  @throw none No throw guarantee
+     */
+    static constexpr Threshold default_threshold() { return Threshold(0.01); }
 
     /** @brief Returns the interval represented by *this.
      *
@@ -213,7 +262,7 @@ public:
         apply_threshold_();
     }
 
-    /** @brief Returns whether *this contains a scalar value.
+    /** @brief Returns whether *this contains a scalar value @p v.
      *
      *  @param[in] v The value to test.
      *  @return True if the value is in range().
@@ -249,7 +298,8 @@ public:
     /** @brief Returns a string of the affine form.
      *
      *  @return Affine form string.
-     *  @throw std::bad_alloc
+     *  @throw std::bad_alloc If memory allocation for the string fails.
+     *                        Strong throw guarantee.
      */
     std::string print_affine_form() const {
         return m_affine_.print_affine_form();
@@ -328,10 +378,24 @@ public:
         return *this;
     }
 
+    /** @brief Returns the sum of *this and a scalar.
+     *
+     *  @param[in] value The scalar to add.
+     *  @return The sum of *this and @p value.
+     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
+     *                        fails. Strong throw guarantee.
+     */
     ThresholdedAffine operator+(value_t value) const {
         return ThresholdedAffine(*this) += value;
     }
 
+    /** @brief Returns the sum of *this and another ThresholdedAffine.
+     *
+     *  @param[in] other The ThresholdedAffine to add.
+     *  @return The sum of *this and @p other.
+     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
+     *                        fails. Strong throw guarantee.
+     */
     ThresholdedAffine operator+(const ThresholdedAffine& other) const {
         return ThresholdedAffine(*this) += other;
     }
@@ -359,10 +423,24 @@ public:
         return *this;
     }
 
+    /** @brief Returns the difference of *this and a scalar.
+     *
+     *  @param[in] value The scalar to subtract.
+     *  @return The difference of *this and @p value.
+     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
+     *                        fails. Strong throw guarantee.
+     */
     ThresholdedAffine operator-(value_t value) const {
         return ThresholdedAffine(*this) -= value;
     }
 
+    /** @brief Returns the difference of *this and another ThresholdedAffine.
+     *
+     *  @param[in] other The ThresholdedAffine to subtract.
+     *  @return The difference of *this and @p other.
+     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
+     *                        fails. Strong throw guarantee.
+     */
     ThresholdedAffine operator-(const ThresholdedAffine& other) const {
         return ThresholdedAffine(*this) -= other;
     }
@@ -395,10 +473,24 @@ public:
         return *this;
     }
 
+    /** @brief Multiplies *this by a scalar.
+     *
+     *  @param[in] value The scalar to multiply by.
+     *  @return The product of *this and @p value.
+     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
+     *                        fails. Strong throw guarantee.
+     */
     ThresholdedAffine operator*(value_t value) const {
         return ThresholdedAffine(*this) *= value;
     }
 
+    /** @brief Multiplies *this by another ThresholdedAffine.
+     *
+     *  @param[in] other The ThresholdedAffine to multiply by.
+     *  @return The product of *this and @p other.
+     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
+     *                        fails. Strong throw guarantee.
+     */
     ThresholdedAffine operator*(const ThresholdedAffine& other) const {
         return ThresholdedAffine(*this) *= other;
     }
@@ -427,10 +519,26 @@ public:
         return *this;
     }
 
+    /** @brief Divides *this by a scalar.
+     *
+     *  @param[in] value The scalar to divide by.
+     *  @return The quotient of *this and @p value.
+     *  @throw std::domain_error If @p value is zero.
+     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
+     *                        fails. Strong throw guarantee.
+     */
     ThresholdedAffine operator/(value_t value) const {
         return ThresholdedAffine(*this) /= value;
     }
 
+    /** @brief Divides *this by another ThresholdedAffine.
+     *
+     *  @param[in] other The ThresholdedAffine to divide by.
+     *  @return The quotient of *this and @p other.
+     *  @throw std::domain_error If @p other is empty or contains zero.
+     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
+     *                        fails. Strong throw guarantee.
+     */
     ThresholdedAffine operator/(const ThresholdedAffine& other) const {
         return ThresholdedAffine(*this) /= other;
     }

--- a/include/sigma/affine/thresholded_affine.hpp
+++ b/include/sigma/affine/thresholded_affine.hpp
@@ -173,14 +173,14 @@ public:
      *  @throw std::bad_alloc If memory allocation for the error terms fails.
      *                        Strong throw guarantee.
      */
-    ThresholdedAffine(const ThresholdedAffine&) = default;
+    ThresholdedAffine(const ThresholdedAffine& other) = default;
 
     /** @brief Move constructor.
      *
      *  @param[in] other The ThresholdedAffine to move.
      *  @throw none No throw guarantee
      */
-    ThresholdedAffine(ThresholdedAffine&&) noexcept = default;
+    ThresholdedAffine(ThresholdedAffine&& other) noexcept = default;
 
     /** @brief Copy assignment operator.
      *
@@ -191,7 +191,7 @@ public:
      *  @throw std::bad_alloc If memory allocation for the error terms fails.
      *                        Strong throw guarantee.
      */
-    ThresholdedAffine& operator=(const ThresholdedAffine&) = default;
+    ThresholdedAffine& operator=(const ThresholdedAffine& other) = default;
 
     /** @brief Move assignment operator.
      *
@@ -201,7 +201,7 @@ public:
      *
      *  @throw none No throw guarantee
      */
-    ThresholdedAffine& operator=(ThresholdedAffine&&) noexcept = default;
+    ThresholdedAffine& operator=(ThresholdedAffine&& other) noexcept = default;
 
     // -- State Accessors -----------------------------------------------------
 

--- a/include/sigma/affine/thresholded_affine.hpp
+++ b/include/sigma/affine/thresholded_affine.hpp
@@ -79,8 +79,7 @@ public:
      *  @throw none No throw guarantee
      */
     ThresholdedAffine() :
-      m_lump_term_(std::make_shared<size_type>(0)),
-      m_threshold_(value_t(0.01)) {}
+      m_lump_term_(affine_t::make_error_term()), m_threshold_(value_t(0.01)) {}
 
     /** @brief Constructs a ThresholdedAffine from a center value.
      *
@@ -92,7 +91,7 @@ public:
     explicit ThresholdedAffine(value_t center,
                                Threshold t = Threshold{value_t(0.01)}) :
       m_affine_(center),
-      m_lump_term_(std::make_shared<size_type>(0)),
+      m_lump_term_(affine_t::make_error_term()),
       m_threshold_(t.value) {
         apply_threshold_();
     }
@@ -108,7 +107,7 @@ public:
     ThresholdedAffine(value_t lo, value_t hi,
                       Threshold t = Threshold{value_t(0.01)}) :
       m_affine_(lo, hi),
-      m_lump_term_(std::make_shared<size_type>(0)),
+      m_lump_term_(affine_t::make_error_term()),
       m_threshold_(t.value) {
         apply_threshold_();
     }
@@ -123,7 +122,7 @@ public:
     explicit ThresholdedAffine(const interval_t& interval,
                                Threshold t = Threshold{value_t(0.01)}) :
       m_affine_(interval),
-      m_lump_term_(std::make_shared<size_type>(0)),
+      m_lump_term_(affine_t::make_error_term()),
       m_threshold_(t.value) {
         apply_threshold_();
     }
@@ -139,7 +138,7 @@ public:
     ThresholdedAffine(value_t center, error_terms_t radii,
                       Threshold t = Threshold{value_t(0.01)}) :
       m_affine_(center, std::move(radii)),
-      m_lump_term_(std::make_shared<size_type>(0)),
+      m_lump_term_(affine_t::make_error_term()),
       m_threshold_(t.value) {
         apply_threshold_();
     }
@@ -156,7 +155,7 @@ public:
      */
     ThresholdedAffine(affine_t a, value_t threshold) :
       m_affine_(std::move(a)),
-      m_lump_term_(std::make_shared<size_type>(0)),
+      m_lump_term_(affine_t::make_error_term()),
       m_threshold_(threshold) {
         apply_threshold_();
     }
@@ -473,10 +472,10 @@ private:
     void apply_threshold_() {
         if(m_affine_.empty()) return;
         auto total_r = m_affine_.radius();
-        if(total_r == value_t(0)) return;
 
         // Work on a snapshot to avoid modifying while iterating
         auto terms = m_affine_.error_terms();
+        if(terms.size() == 0) return; // No error terms to threshold
 
         value_t lump_delta          = value_t(0);
         value_t existing_lump_coeff = value_t(0);
@@ -487,7 +486,12 @@ private:
                 existing_lump_coeff = coeff;
                 continue;
             }
-            if(std::fabs(coeff) / total_r < m_threshold_) {
+            if(std::fabs(coeff) < std::numeric_limits<value_t>::epsilon()) {
+                // Skip zero terms to avoid unnecessary lumping and preserve
+                // sparsity.
+                continue;
+            } else if(total_r != value_t(0) &&
+                      std::fabs(coeff) / total_r < m_threshold_) {
                 lump_delta += std::fabs(coeff);
             } else {
                 new_terms[sym] = coeff;

--- a/include/sigma/sigma.hpp
+++ b/include/sigma/sigma.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "affine/affine.hpp"
+#include "affine/thresholded_affine.hpp"
 #include "interval/interval.hpp"
 #include "uncertain/uncertain.hpp"
 

--- a/tests/unit_tests/affine/test_affine.cpp
+++ b/tests/unit_tests/affine/test_affine.cpp
@@ -5,10 +5,9 @@
 using testing::test_affine;
 
 TEMPLATE_TEST_CASE("Affine", "", float, double) {
-    using value_t      = TestType;
-    using affine_t     = sigma::Affine<TestType>;
-    using interval_t   = typename affine_t::interval_t;
-    using error_term_t = typename affine_t::error_term_t;
+    using value_t    = TestType;
+    using affine_t   = sigma::Affine<TestType>;
+    using interval_t = typename affine_t::interval_t;
 
     value_t zero  = 0.0;
     value_t one   = 1.0;
@@ -50,7 +49,8 @@ TEMPLATE_TEST_CASE("Affine", "", float, double) {
         }
 
         SECTION("From Center and Error Terms") {
-            affine_t value(one, {{error_term_t{}, one}});
+            auto sym = affine_t::make_error_term();
+            affine_t value(one, {{sym, one}});
             test_affine(value, zero, two);
         }
 
@@ -172,7 +172,7 @@ TEMPLATE_TEST_CASE("Affine", "", float, double) {
         affine_t interval(one, two);
         REQUIRE(interval.radius() == value_t(0.5));
 
-        interval.add_error_term(error_term_t{}, value_t(-0.1));
+        interval.add_error_term(affine_t::make_error_term(), value_t(-0.1));
         REQUIRE(interval.radius() == value_t(0.6));
     }
 
@@ -192,15 +192,15 @@ TEMPLATE_TEST_CASE("Affine", "", float, double) {
 
     SECTION("add_error_term") {
         affine_t empty;
-        empty.add_error_term(error_term_t{}, one);
+        empty.add_error_term(affine_t::make_error_term(), one);
         test_affine(empty, -one, one);
 
         affine_t point(one);
-        point.add_error_term(error_term_t{}, value_t(0.5));
+        point.add_error_term(affine_t::make_error_term(), value_t(0.5));
         test_affine(point, value_t(0.5), value_t(1.5));
 
         affine_t interval(one, two);
-        interval.add_error_term(error_term_t{}, value_t(0.25));
+        interval.add_error_term(affine_t::make_error_term(), value_t(0.25));
         test_affine(interval, value_t(0.75), value_t(2.25));
     }
 
@@ -344,12 +344,13 @@ TEMPLATE_TEST_CASE("Affine", "", float, double) {
         // Test the addition of dependent errors
         // x = 1.5 +/- 0.5 e_0 +/- 1.0 e_1
         affine_t dependent(one, two);
-        dependent.add_error_term(error_term_t{}, one);
+        auto shared_sym = affine_t::make_error_term();
+        dependent.add_error_term(shared_sym, one);
 
-        // y = 1 -/+ 1 e_1
+        // y = 1 -/+ 1 e_1 (same e_1, so it cancels with dependent's e_1)
         affine_t other_dependent;
         other_dependent.set_center(one);
-        other_dependent.add_error_term(error_term_t{}, -one);
+        other_dependent.add_error_term(shared_sym, -one);
         auto pdependent = &(dependent += other_dependent);
         REQUIRE(pdependent == &dependent);
         test_affine(dependent, two, three);

--- a/tests/unit_tests/affine/test_thresholded_affine.cpp
+++ b/tests/unit_tests/affine/test_thresholded_affine.cpp
@@ -71,8 +71,8 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
         }
 
         SECTION("From Center and Error Terms") {
-            using error_term_t = typename ta_t::error_term_t;
-            ta_t value(one, {{error_term_t{}, one}});
+            auto sym = affine_t::make_error_term();
+            ta_t value(one, {{sym, one}});
             test_affine(value, zero, two);
         }
 
@@ -110,7 +110,7 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
         REQUIRE(interval.radius() == value_t(0.5));
         REQUIRE_FALSE(interval.empty());
         REQUIRE(interval.threshold() == value_t(0.01));
-        REQUIRE(interval.lump_term() != nullptr);
+        // lump_term() is a size_t ID, always valid (no null concept)
     }
 
     SECTION("Threshold") {

--- a/tests/unit_tests/affine/test_thresholded_affine.cpp
+++ b/tests/unit_tests/affine/test_thresholded_affine.cpp
@@ -1,0 +1,356 @@
+#include "catch2/catch_test_macros.hpp"
+#include "testing.hpp"
+#include <sigma/affine/thresholded_affine.hpp>
+#include <sstream>
+
+using testing::test_affine;
+
+// Convenience aliases
+using TAFloat  = sigma::TAFloat;
+using TADouble = sigma::TADouble;
+
+// Helper: verify that a ThresholdedAffine's range contains the equivalent
+// Affine range. Used to assert conservatism.
+template<typename TA>
+void contains_affine_range(const TA& ta,
+                           const sigma::Affine<typename TA::value_t>& a) {
+    REQUIRE(ta.contains(a.range()));
+}
+
+TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
+    using ta_t        = TestType;
+    using value_t     = typename ta_t::value_t;
+    using affine_t    = sigma::Affine<value_t>;
+    using interval_t  = typename ta_t::interval_t;
+    using threshold_t = typename ta_t::Threshold;
+
+    const value_t zero  = value_t(0.0);
+    const value_t one   = value_t(1.0);
+    const value_t two   = value_t(2.0);
+    const value_t three = value_t(3.0);
+    const value_t four  = value_t(4.0);
+
+    // A threshold low enough that single-term forms never get lumped.
+    const threshold_t no_lump{value_t(0.0)};
+    // A threshold high enough to lump almost everything.
+    const threshold_t big_t{value_t(0.5)};
+    // The default threshold (1%).
+    const threshold_t def_t{value_t(0.01)};
+
+    SECTION("Constructors") {
+        SECTION("Default") {
+            ta_t empty;
+            REQUIRE(empty.empty());
+        }
+
+        SECTION("From Center") {
+            ta_t value(one);
+            test_affine(value, one, one);
+
+            ta_t value2(zero);
+            test_affine(value2, zero, zero);
+        }
+
+        SECTION("From Lower and Upper") {
+            ta_t value(one, two);
+            test_affine(value, one, two);
+
+            ta_t point(one, one);
+            test_affine(point, one, one);
+        }
+
+        SECTION("From Interval") {
+            ta_t empty_int(interval_t{});
+            REQUIRE(empty_int.empty());
+
+            ta_t value(interval_t(one, two));
+            test_affine(value, one, two);
+
+            ta_t value2(interval_t(-two, three));
+            test_affine(value2, -two, three);
+        }
+
+        SECTION("From Center and Error Terms") {
+            using error_term_t = typename ta_t::error_term_t;
+            ta_t value(one, {{error_term_t{}, one}});
+            test_affine(value, zero, two);
+        }
+
+        SECTION("Copy Constructor") {
+            ta_t empty;
+            ta_t copy_empty(empty);
+            REQUIRE(copy_empty.empty());
+            REQUIRE(copy_empty == empty);
+
+            ta_t point(one);
+            ta_t copy_point(point);
+            test_affine(copy_point, one, one);
+            REQUIRE(copy_point == point);
+
+            ta_t interval(one, two);
+            ta_t copy_interval(interval);
+            test_affine(copy_interval, one, two);
+            REQUIRE(copy_interval == interval);
+        }
+
+        SECTION("Move Constructor") {
+            ta_t empty;
+            ta_t move_empty(std::move(empty));
+            REQUIRE(move_empty.empty());
+
+            ta_t point(one);
+            ta_t move_point(std::move(point));
+            test_affine(move_point, one, one);
+        }
+    }
+
+    SECTION("Accessors") {
+        ta_t interval(one, two);
+        REQUIRE(interval.center() == value_t(1.5));
+        REQUIRE(interval.radius() == value_t(0.5));
+        REQUIRE_FALSE(interval.empty());
+        REQUIRE(interval.threshold() == value_t(0.01));
+        REQUIRE(interval.lump_term() != nullptr);
+    }
+
+    SECTION("Threshold") {
+        SECTION("No lumping for a single-term form") {
+            // A single-term form has relative contribution 1.0, never lumped.
+            ta_t x(one, two, def_t);
+            // Should have exactly one error term (the interval's epsilon).
+            // The lump term should NOT be present (or have zero coefficient).
+            auto terms = x.error_terms();
+            // Count non-zero terms
+            std::size_t nonzero = 0;
+            for(auto&& [sym, coeff] : terms) {
+                if(coeff != value_t(0)) ++nonzero;
+            }
+            REQUIRE(nonzero == 1);
+        }
+
+        SECTION("Lumping reduces term count after multiplication") {
+            // x in [1, 2], y in [1, 2] — multiply to get nonlinearity term.
+            // With a tight threshold the nonlinearity correction (0.25) is
+            // small relative to the main terms (~0.5 each), so it may be
+            // lumped at threshold > ~0.2.
+            ta_t x(one, two, big_t);
+            ta_t y(one, two, big_t);
+            ta_t z = x * y;
+
+            // The corresponding Affine result
+            affine_t ax(one, two), ay(one, two);
+            affine_t az = ax * ay;
+
+            // ThresholdedAffine result must contain the Affine result.
+            contains_affine_range(z, az);
+
+            // With big threshold, the new nonlinearity term is likely lumped.
+            // Verify that z has fewer unique symbols than az (or at most
+            // equal).
+            REQUIRE(z.error_terms().size() <= az.error_terms().size());
+        }
+
+        SECTION("Lumped lump term grows monotonically") {
+            // Start with [1, 2] and multiply repeatedly; each multiplication
+            // adds a nonlinearity term.  With a high threshold, these get
+            // absorbed into the lump, so the total term count stays small.
+            ta_t x(one, two, big_t);
+            std::size_t prev_count = x.error_terms().size();
+            for(int i = 0; i < 5; ++i) {
+                ta_t bump(value_t(1.0), value_t(1.01), big_t);
+                x *= bump;
+                // Symbol count should stay bounded (≤ prev + 1 at most,
+                // and often stays the same due to lumping).
+                REQUIRE(x.error_terms().size() <= prev_count + 2);
+                prev_count = x.error_terms().size();
+            }
+        }
+    }
+
+    SECTION("Conservatism: range always contains Affine range") {
+        affine_t ax(one, two), ay(two, three);
+        ta_t tx(one, two, def_t), ty(two, three, def_t);
+
+        SECTION("Addition") { contains_affine_range(tx + ty, ax + ay); }
+        SECTION("Subtraction") { contains_affine_range(tx - ty, ax - ay); }
+        SECTION("Multiplication") { contains_affine_range(tx * ty, ax * ay); }
+        SECTION("Division") { contains_affine_range(tx / ty, ax / ay); }
+        SECTION("sqrt") {
+            contains_affine_range(sigma::sqrt(tx), sigma::sqrt(ax));
+        }
+        SECTION("exp") {
+            contains_affine_range(sigma::exp(tx), sigma::exp(ax));
+        }
+        SECTION("log") {
+            contains_affine_range(sigma::log(tx), sigma::log(ax));
+        }
+        SECTION("abs") {
+            ta_t tneg(-two, -one, def_t);
+            affine_t aneg(-two, -one);
+            contains_affine_range(sigma::abs(tneg), sigma::abs(aneg));
+        }
+    }
+
+    SECTION("Arithmetic") {
+        SECTION("Scalar add") {
+            ta_t x(one, two, no_lump);
+            x += two;
+            test_affine(x, three, four);
+        }
+
+        SECTION("Scalar subtract") {
+            ta_t x(one, two, no_lump);
+            x -= one;
+            test_affine(x, zero, one);
+        }
+
+        SECTION("Scalar multiply") {
+            ta_t x(one, two, no_lump);
+            x *= two;
+            test_affine(x, two, four);
+        }
+
+        SECTION("Scalar divide") {
+            ta_t x(two, four, no_lump);
+            x /= two;
+            test_affine(x, one, two);
+        }
+
+        SECTION("Affine add") {
+            ta_t x(one, two, no_lump), y(two, three, no_lump);
+            test_affine(x + y, three, value_t(5.0));
+        }
+
+        SECTION("Unary minus") {
+            ta_t x(one, two, no_lump);
+            test_affine(-x, -two, -one);
+        }
+
+        SECTION("Dependent subtraction: x - x") {
+            // With no_lump, x shares its error symbol with its copy, so
+            // x - x = 0 exactly (same as Affine).
+            ta_t x(one, two, no_lump);
+            ta_t result = x - x;
+            REQUIRE(result.radius() == zero);
+        }
+
+        SECTION("Scalar right multiply") {
+            ta_t x(one, two, no_lump);
+            ta_t result = two * x;
+            test_affine(result, two, four);
+        }
+    }
+
+    SECTION("Comparison") {
+        ta_t x(one, two);
+        ta_t y = x; // copy shares same error symbols
+        ta_t z(two, three);
+        REQUIRE(x == y);
+        REQUIRE_FALSE(x == z);
+        REQUIRE(x != z);
+    }
+
+    SECTION("Contains") {
+        ta_t x(one, two, no_lump);
+        REQUIRE(x.contains(one));
+        REQUIRE(x.contains(two));
+        REQUIRE(x.contains(value_t(1.5)));
+        REQUIRE_FALSE(x.contains(zero));
+        REQUIRE_FALSE(x.contains(three));
+
+        REQUIRE(x.contains(interval_t(one, two)));
+        REQUIRE(x.contains(interval_t(one, value_t(1.5))));
+        REQUIRE_FALSE(x.contains(interval_t(zero, two)));
+
+        ta_t y(one, value_t(1.5), no_lump);
+        REQUIRE(x.contains(y));
+        ta_t z(zero, two, no_lump);
+        REQUIRE_FALSE(x.contains(z));
+    }
+
+    SECTION("Empty form behavior") {
+        ta_t empty;
+        REQUIRE(empty.empty());
+        REQUIRE(empty.range().empty());
+        REQUIRE_FALSE(empty.contains(zero));
+    }
+
+    SECTION("Stream output") {
+        ta_t x(one, two, no_lump);
+        std::ostringstream os;
+        os << x;
+        REQUIRE_FALSE(os.str().empty());
+    }
+
+    SECTION("Operations") {
+        ta_t x(one, two, no_lump);
+
+        SECTION("sqrt") {
+            test_affine(sigma::sqrt(x), one, value_t(1.43198051533946));
+        }
+
+        SECTION("exp") {
+            // Tight value is [e, e^2] = [2.71828182846..., 7.38905609893...],
+            // but the affine transformation adds some error.
+            test_affine(sigma::exp(x), value_t(2.14236806757880416),
+                        value_t(7.38905609893));
+        }
+
+        SECTION("log") {
+            test_affine(sigma::log(x), value_t(0.0), value_t(0.752807281701));
+        }
+
+        SECTION("abs positive") {
+            auto result = sigma::abs(x);
+            REQUIRE(result == x);
+        }
+
+        SECTION("abs negative") {
+            ta_t neg(-two, -one, no_lump);
+            auto result = sigma::abs(neg);
+            test_affine(result, one, two);
+        }
+
+        SECTION("fabs") {
+            ta_t neg(-two, -one, no_lump);
+            auto result = sigma::fabs(neg);
+            test_affine(result, one, two);
+        }
+
+        SECTION("pow") {
+            auto result = sigma::pow(x, value_t(2.0));
+            REQUIRE(result.contains(one));
+            REQUIRE(result.contains(four));
+        }
+    }
+
+    SECTION("Lump term behavior") {
+        SECTION("Lump term shared across copies (cancellation)") {
+            // When x is copied to y and both have the same lump symbol,
+            // y - x should have a small lump contribution.
+            // With no_lump threshold, no lumping occurs and the cancellation
+            // is exact (as in Affine).
+            ta_t x(one, two, no_lump);
+            ta_t y    = x; // shares lump symbol via copy
+            ta_t diff = y - x;
+            REQUIRE(diff.radius() == zero);
+        }
+
+        SECTION("Independent forms have distinct lump symbols") {
+            // Two independently created forms with distinct lump symbols
+            // should not cancel their lump contributions.
+            ta_t x(one, two, big_t);
+            ta_t z(one, two, big_t); // fresh construction: new lump symbol
+            // Force some lumping by multiplying
+            x *= ta_t(one, value_t(1.01), big_t);
+            z *= ta_t(one, value_t(1.01), big_t);
+            // x and z are independent — their difference should NOT be zero
+            // (the lump symbols differ).
+            // We just verify the forms are conservative.
+            affine_t ax(one, two), az(one, two);
+            affine_t ax2(one, value_t(1.01)), az2(one, value_t(1.01));
+            contains_affine_range(x, ax * ax2);
+            contains_affine_range(z, az * az2);
+        }
+    }
+}


### PR DESCRIPTION
The number of error symbols in the `Affine` class grows with each non-affine operation. This leads to an explosion in symbols. The `ThresholdedAffine` class attempts to prevent this explosion while still maintaining rigorous error bounds. Internally this is done by lumping errors below a relative threshold into a single error symbol.

I'm still propagating this up the stack and want to make sure I didn't miss anything. I also need to see if the default value of 1% is reasonable.