### PR TITLE
Modifies taffine to drop terms

### DIFF
--- a/include/sigma/affine/thresholded_affine.hpp
+++ b/include/sigma/affine/thresholded_affine.hpp
@@ -8,7 +8,7 @@
 
 namespace sigma {
 
-/** @brief Implements affine arithmetic with small-term lumping.
+/** @brief Implements affine arithmetic that drops negligible error terms.
  *
  * @tparam ValueType The numeric type of the center and error term radii.
  *
@@ -18,24 +18,9 @@ namespace sigma {
  * creates a nonlinearity symbol); without pruning, the symbol count grows
  * unboundedly.
  *
- * This class reduces symbol proliferation by collapsing small error terms into
- * a non-negative unsigned lump radius @f$R_\ell@f$. After each operation, any
- * error term whose relative contribution to the total radius falls below a
- * user-specified threshold @f$t@f$ is folded into the lump:
- * @f[
- *   \frac{|x_i|}{\text{total\_radius}} < t \implies |x_i| \text{ is added to }
- * R_\ell
- * @f]
- *
- * The lump is stored as a plain non-negative radius, not as a signed affine
- * coefficient. It always contributes @f$+R_\ell@f$ to the total radius and is
- * combined by addition in both addition and subtraction of two
- * ThresholdedAffine values. This guarantees that absorbed independent errors
- * can never cancel against each other.
- *
- * The total interval represented is
- * @f$[\text{center} - \text{radius}(),\, \text{center} + \text{radius}()]@f$
- * where @f$\text{radius}() = \sum_i |x_i| + R_\ell@f$.
+ * This class reduces symbol count by deleting error terms whose relative
+ * contribution falls below the threshold. Dropped terms are simply discarded;
+ * no separate "lump" radius is retained to account for them.
  *
  * Constructors accept a @ref Threshold tag type to distinguish the threshold
  * parameter from ordinary value parameters and avoid constructor ambiguity.
@@ -83,8 +68,8 @@ public:
 
     /** @brief Constructs an empty ThresholdedAffine.
      *
-     *  The resulting ThresholdedAffine represents the empty set. The lump
-     *  radius is zero and the threshold is set to the default value.
+     *  The resulting ThresholdedAffine represents the empty set and the
+     *  threshold is set to the default value.
      *
      *  @throw none No throw guarantee
      */
@@ -149,21 +134,16 @@ public:
     /** @brief Constructs a ThresholdedAffine by wrapping an Affine form.
      *
      *  Used internally by operations that produce an Affine result and need to
-     *  re-wrap it as a ThresholdedAffine, optionally carrying an existing lump
-     *  radius.
+     *  re-wrap it as a ThresholdedAffine.
      *
-     *  @param[in] a            The Affine form to wrap.
-     *  @param[in] threshold    The relative threshold.
-     *  @param[in] lump_radius  Initial non-negative lump radius to carry over.
+     *  @param[in] a         The Affine form to wrap.
+     *  @param[in] threshold The relative threshold.
      *
      *  @throw std::bad_alloc If memory allocation for the error term fails.
      *                        Strong throw guarantee.
      */
-    ThresholdedAffine(affine_t a, value_t threshold,
-                      value_t lump_radius = value_t(0)) :
-      m_affine_(std::move(a)),
-      m_lump_radius_(lump_radius),
-      m_threshold_(threshold) {
+    ThresholdedAffine(affine_t a, value_t threshold) :
+      m_affine_(std::move(a)), m_threshold_(threshold) {
         apply_threshold_();
     }
 
@@ -208,22 +188,22 @@ public:
 
     /** @brief Returns the default threshold value.
      *
-     *  @return The default threshold (1%).
+     *  @return The default threshold (0.1%).
      *  @throw none No throw guarantee
      */
-    static constexpr Threshold default_threshold() { return Threshold(0.01); }
+    static constexpr Threshold default_threshold() { return Threshold(0.001); }
 
     /** @brief Returns the interval represented by *this.
      *
      *  The interval is [center - radius(), center + radius()], where radius()
-     *  includes both the tracked affine terms and the unsigned lump radius.
+     *  is the sum of the tracked affine terms.
      *
      *  @return The interval.
      *  @throw none No throw guarantee
      */
     interval_t range() const {
         if(m_affine_.empty()) return interval_t{};
-        auto r = m_affine_.radius() + m_lump_radius_;
+        auto r = m_affine_.radius();
         return interval_t(m_affine_.center() - r, m_affine_.center() + r);
     }
 
@@ -236,26 +216,17 @@ public:
 
     /** @brief Returns the error terms of the tracked affine form.
      *
-     *  Does not include the unsigned lump radius; use lump_radius() for that.
-     *
      *  @return Const reference to the error terms map.
      *  @throw None No throw guarantee.
      */
     const error_terms_t& error_terms() const { return m_affine_.error_terms(); }
 
-    /** @brief Returns the total radius: sum of tracked terms plus lump radius.
+    /** @brief Returns the total radius: the sum of the tracked terms.
      *
      *  @return The total radius.
      *  @throw std::domain_error If *this is empty.
      */
-    value_t radius() const { return m_affine_.radius() + m_lump_radius_; }
-
-    /** @brief Returns the unsigned lump radius accumulated so far.
-     *
-     *  @return Non-negative lump radius.
-     *  @throw none No throw guarantee.
-     */
-    value_t lump_radius() const { return m_lump_radius_; }
+    value_t radius() const { return m_affine_.radius(); }
 
     /** @brief Sets the center of the affine form.
      *
@@ -320,7 +291,7 @@ public:
 
     /** @brief Returns a string of the interval form.
      *
-     *  @return Interval form string, e.g. [lo, hi], including the lump.
+     *  @return Interval form string, e.g. [lo, hi].
      *  @throw std::bad_alloc
      */
     std::string print_interval_form() const {
@@ -345,8 +316,7 @@ public:
 
     /** @brief Returns the additive inverse of *this.
      *
-     *  Negation flips the tracked affine terms; the unsigned lump radius is
-     *  unchanged because it represents a magnitude, not a signed coefficient.
+     *  Negation flips the tracked affine terms.
      *
      *  @return The negated ThresholdedAffine.
      *  @throw std::bad_alloc If memory allocation fails.
@@ -354,7 +324,6 @@ public:
     ThresholdedAffine operator-() const {
         auto result      = *this;
         result.m_affine_ = -m_affine_;
-        // m_lump_radius_ is unsigned; it does not negate.
         return result;
     }
 
@@ -372,8 +341,8 @@ public:
     /** @brief Adds another ThresholdedAffine to *this.
      *
      *  The tracked affine terms are combined with normal affine addition
-     *  (shared symbols may cancel). The lump radii are added unconditionally
-     *  because they represent unsigned independent uncertainty.
+     *  (shared symbols may cancel), after which sub-threshold terms are
+     *  dropped.
      *
      *  @param[in] other The form to add.
      *  @return Reference to *this.
@@ -381,7 +350,6 @@ public:
      */
     ThresholdedAffine& operator+=(const ThresholdedAffine& other) {
         m_affine_ += other.m_affine_;
-        m_lump_radius_ += other.m_lump_radius_;
         apply_threshold_();
         return *this;
     }
@@ -410,9 +378,8 @@ public:
     /** @brief Subtracts another ThresholdedAffine from *this.
      *
      *  Tracked affine terms are combined with normal affine subtraction
-     *  (shared symbols cancel, capturing dependency). The lump radii are
-     *  *added* — not subtracted — because the lump is an unsigned bound on
-     *  independent accumulated errors that cannot cancel.
+     *  (shared symbols cancel, capturing dependency), after which sub-threshold
+     *  terms are dropped.
      *
      *  @param[in] other The form to subtract.
      *  @return Reference to *this.
@@ -420,7 +387,6 @@ public:
      */
     ThresholdedAffine& operator-=(const ThresholdedAffine& other) {
         m_affine_ -= other.m_affine_;
-        m_lump_radius_ += other.m_lump_radius_;
         apply_threshold_();
         return *this;
     }
@@ -437,15 +403,12 @@ public:
 
     /** @brief Multiplies *this by a scalar.
      *
-     *  The lump radius is scaled by @p |value|.
-     *
      *  @param[in] value The scalar to multiply by.
      *  @return Reference to *this.
      *  @throw None No throw guarantee.
      */
     ThresholdedAffine& operator*=(value_t value) {
         m_affine_ *= value;
-        m_lump_radius_ *= std::fabs(value);
         apply_threshold_();
         return *this;
     }
@@ -453,33 +416,14 @@ public:
     /** @brief Multiplies *this by another ThresholdedAffine.
      *
      *  Multiplication introduces a new nonlinearity error term via affine
-     *  arithmetic, plus contributions from each operand's lump radius
-     * interacting with the other operand's affine bound.
+     *  arithmetic, after which sub-threshold terms are dropped.
      *
      *  @param[in] other The form to multiply by.
      *  @return Reference to *this.
      *  @throw None No throw guarantee.
      */
     ThresholdedAffine& operator*=(const ThresholdedAffine& other) {
-        // Save pre-multiplication bounds needed for lump propagation.
-        value_t a_max = m_affine_.empty() ?
-                          value_t(0) :
-                          std::fabs(m_affine_.center()) + m_affine_.radius();
-        value_t b_max =
-          other.m_affine_.empty() ?
-            value_t(0) :
-            std::fabs(other.m_affine_.center()) + other.m_affine_.radius();
-        value_t a_lump = m_lump_radius_;
-        value_t b_lump = other.m_lump_radius_;
-
         m_affine_ *= other.m_affine_;
-
-        // Lump contributions from the product:
-        //   a_affine × b_lump  bounded by a_max × b_lump
-        //   a_lump × b_affine  bounded by a_lump × b_max
-        //   a_lump × b_lump
-        m_lump_radius_ = a_lump * (b_max + b_lump) + a_max * b_lump;
-
         apply_threshold_();
         return *this;
     }
@@ -502,43 +446,30 @@ public:
      */
     ThresholdedAffine& operator/=(value_t value) {
         m_affine_ /= value;
-        m_lump_radius_ /= std::fabs(value);
         apply_threshold_();
         return *this;
     }
 
     /** @brief Divides *this by another ThresholdedAffine.
      *
-     *  The lump radius of the divisor expands its interval, contributing
-     *  additional uncertainty to the quotient.  A conservative bound is used:
-     *  the divisor's full interval (affine ± lump) determines the minimum
-     *  absolute value @f$b_\min@f$ used to scale the result's lump.
+     *  Division is performed by affine arithmetic, after which sub-threshold
+     *  terms are dropped. The divisor's interval must not contain zero.
      *
      *  @param[in] other The form to divide by.
      *  @return Reference to *this.
-     *  @throw std::domain_error If @p other is empty or its full interval
+     *  @throw std::domain_error If @p other is empty or its interval
      *                           contains zero.
      */
     ThresholdedAffine& operator/=(const ThresholdedAffine& other) {
-        // Minimum absolute value of other over its full interval (affine +
-        // lump).
-        value_t other_total = other.m_affine_.radius() + other.m_lump_radius_;
+        // Minimum absolute value of other over its interval.
+        value_t other_total = other.m_affine_.radius();
         value_t b_min       = std::fabs(other.m_affine_.center()) - other_total;
         if(b_min <= value_t(0)) {
             throw std::domain_error(
               "ThresholdedAffine division by interval containing zero");
         }
 
-        value_t pre_lump = m_lump_radius_;
-
         m_affine_ /= other.m_affine_;
-
-        // this's lump scaled by 1/|b_min|, plus additional uncertainty from
-        // other's lump acting on the result: result_bound × b_lump / b_min.
-        value_t result_bound =
-          std::fabs(m_affine_.center()) + m_affine_.radius() + m_lump_radius_;
-        m_lump_radius_ =
-          pre_lump / b_min + result_bound * other.m_lump_radius_ / b_min;
 
         apply_threshold_();
         return *this;
@@ -564,7 +495,6 @@ public:
      */
     bool operator==(const ThresholdedAffine& other) const {
         return m_affine_ == other.m_affine_ &&
-               m_lump_radius_ == other.m_lump_radius_ &&
                m_threshold_ == other.m_threshold_;
     }
 
@@ -579,17 +509,16 @@ public:
     }
 
 private:
-    /** @brief Absorbs error terms below the relative threshold into the
-     *         unsigned lump radius.
+    /** @brief Drops error terms whose relative contribution is below the
+     *         threshold.
      *
      *  After each arithmetic operation, scans all error terms in m_affine_.
      *  Terms with @f$|x_i| / \text{total\_radius} < t@f$ are removed and
-     *  their absolute coefficient is added to @p m_lump_radius_.
-     *  total_radius includes the existing lump radius.
+     *  discarded; their contribution is not retained anywhere.
      */
     void apply_threshold_() {
         if(m_affine_.empty()) return;
-        auto total_r = m_affine_.radius() + m_lump_radius_;
+        auto total_r = m_affine_.radius();
 
         auto terms = m_affine_.error_terms();
         if(terms.empty()) return;
@@ -600,7 +529,6 @@ private:
                 continue;
             } else if(total_r != value_t(0) &&
                       std::fabs(coeff) / total_r < m_threshold_) {
-                m_lump_radius_ += std::fabs(coeff);
             } else {
                 new_terms[sym] = coeff;
             }
@@ -608,14 +536,11 @@ private:
         m_affine_ = affine_t(m_affine_.center(), std::move(new_terms));
     }
 
-    /// The tracked affine form (does not contain the lump).
+    /// The tracked affine form.
     affine_t m_affine_;
 
-    /// Non-negative accumulated radius for absorbed small terms.
-    value_t m_lump_radius_{value_t(0)};
-
     /// Relative threshold: terms with |x_i| / total_radius < m_threshold_ are
-    /// lumped.
+    /// dropped.
     value_t m_threshold_;
 };
 
@@ -648,15 +573,12 @@ ThresholdedAffine<ValueType> operator*(ValueType value,
 
 /** @brief Absolute value of a ThresholdedAffine.
  *
- *  The lump radius is unchanged (abs is Lipschitz-1).
- *
  *  @related ThresholdedAffine
  *  @tparam T The value type.
  */
 template<typename T>
 ThresholdedAffine<T> abs(const ThresholdedAffine<T>& a) {
-    return ThresholdedAffine<T>(abs(a.affine()), a.threshold(),
-                                a.lump_radius());
+    return ThresholdedAffine<T>(abs(a.affine()), a.threshold());
 }
 
 /** @brief Absolute value of a ThresholdedAffine (alias for abs).
@@ -666,15 +588,10 @@ ThresholdedAffine<T> abs(const ThresholdedAffine<T>& a) {
  */
 template<typename T>
 ThresholdedAffine<T> fabs(const ThresholdedAffine<T>& a) {
-    return ThresholdedAffine<T>(fabs(a.affine()), a.threshold(),
-                                a.lump_radius());
+    return ThresholdedAffine<T>(fabs(a.affine()), a.threshold());
 }
 
 /** @brief Square root of a ThresholdedAffine.
- *
- *  The lump is propagated by the Lipschitz constant of sqrt over a's range:
- *  @f$1 / (2 \sqrt{x_\min})@f$ where @f$x_\min@f$ is the lower bound of a's
- *  full interval.
  *
  *  @related ThresholdedAffine
  *  @tparam T The value type.
@@ -682,32 +599,20 @@ ThresholdedAffine<T> fabs(const ThresholdedAffine<T>& a) {
  */
 template<typename T>
 ThresholdedAffine<T> sqrt(const ThresholdedAffine<T>& a) {
-    T x_min = a.center() - a.radius();
-    T lip   = x_min > T(0) ? T(1) / (T(2) * std::sqrt(x_min)) : T(1);
-    return ThresholdedAffine<T>(sqrt(a.affine()), a.threshold(),
-                                a.lump_radius() * lip);
+    return ThresholdedAffine<T>(sqrt(a.affine()), a.threshold());
 }
 
 /** @brief Exponential of a ThresholdedAffine.
- *
- *  The lump is propagated by the Lipschitz constant of exp over a's range:
- *  @f$\exp(x_\max)@f$ where @f$x_\max@f$ is the upper bound of a's full
- *  interval.
  *
  *  @related ThresholdedAffine
  *  @tparam T The value type.
  */
 template<typename T>
 ThresholdedAffine<T> exp(const ThresholdedAffine<T>& a) {
-    T x_max = a.center() + a.radius();
-    return ThresholdedAffine<T>(exp(a.affine()), a.threshold(),
-                                a.lump_radius() * std::exp(x_max));
+    return ThresholdedAffine<T>(exp(a.affine()), a.threshold());
 }
 
 /** @brief Natural logarithm of a ThresholdedAffine.
- *
- *  The lump is propagated by the Lipschitz constant of log over a's range:
- *  @f$1/x_\min@f$ where @f$x_\min@f$ is the lower bound of a's full interval.
  *
  *  @related ThresholdedAffine
  *  @tparam T The value type.
@@ -715,16 +620,10 @@ ThresholdedAffine<T> exp(const ThresholdedAffine<T>& a) {
  */
 template<typename T>
 ThresholdedAffine<T> log(const ThresholdedAffine<T>& a) {
-    T x_min = a.center() - a.radius();
-    T lip   = x_min > T(0) ? T(1) / x_min : T(1);
-    return ThresholdedAffine<T>(log(a.affine()), a.threshold(),
-                                a.lump_radius() * lip);
+    return ThresholdedAffine<T>(log(a.affine()), a.threshold());
 }
 
 /** @brief Power of a ThresholdedAffine.
- *
- *  The lump is propagated conservatively using the maximum of @f$|n \cdot
- *  x^{n-1}|@f$ over a's full interval.
  *
  *  @related ThresholdedAffine
  *  @tparam T The value type.
@@ -733,14 +632,7 @@ ThresholdedAffine<T> log(const ThresholdedAffine<T>& a) {
  */
 template<typename T, typename U>
 ThresholdedAffine<T> pow(const ThresholdedAffine<T>& a, const U& exp) {
-    T x_hi = a.center() + a.radius();
-    T x_lo = a.center() - a.radius();
-    // |d(x^n)/dx| = |n| * |x|^(n-1); max over [x_lo, x_hi]
-    T lip = std::fabs(static_cast<T>(exp)) *
-            std::max(std::pow(std::fabs(x_lo), static_cast<T>(exp) - T(1)),
-                     std::pow(std::fabs(x_hi), static_cast<T>(exp) - T(1)));
-    return ThresholdedAffine<T>(pow(a.affine(), exp), a.threshold(),
-                                a.lump_radius() * lip);
+    return ThresholdedAffine<T>(pow(a.affine(), exp), a.threshold());
 }
 
 /// Typedef for a thresholded affine form of floats

--- a/include/sigma/affine/thresholded_affine.hpp
+++ b/include/sigma/affine/thresholded_affine.hpp
@@ -529,6 +529,7 @@ private:
                 continue;
             } else if(total_r != value_t(0) &&
                       std::fabs(coeff) / total_r < m_threshold_) {
+                continue;
             } else {
                 new_terms[sym] = coeff;
             }

--- a/include/sigma/affine/thresholded_affine.hpp
+++ b/include/sigma/affine/thresholded_affine.hpp
@@ -18,19 +18,22 @@ namespace sigma {
  * creates a nonlinearity symbol); without pruning, the symbol count grows
  * unboundedly.
  *
- * This class reduces symbol proliferation by collapsing small error terms into
- * a single persistent "lump" symbol. After each operation, any error term
- * whose relative contribution to the total radius falls below a user-specified
- * threshold @f$t@f$ is folded into the lump:
+ * This class reduces symbol proliferation by replacing small error terms with
+ * fresh independent symbols. After each operation, any error term whose
+ * relative contribution to the total radius falls below a user-specified
+ * threshold @f$t@f$ is replaced by a new unique noise symbol carrying the same
+ * magnitude:
  * @f[
- *   \frac{|x_i|}{\sum_j |x_j|} < t \implies x_i \text{ is lumped}
+ *   \frac{|x_i|}{\sum_j |x_j|} < t \implies x_i \epsilon_i \to |x_i|
+ * \epsilon_\text{fresh}
  * @f]
  *
- * The resulting interval is always a superset of the interval that would be
- * produced by an unthresholded Affine form, so the approach is conservative
- * (sound). The only loss relative to full affine arithmetic is that small
- * dependent error terms that would otherwise cancel may no longer cancel after
- * lumping.
+ * Each absorption event creates a globally unique symbol, so absorbed terms
+ * from independent sources can never cancel each other. The resulting interval
+ * is always a superset of the interval produced by an unthresholded Affine
+ * form (conservative/sound). The only loss relative to full affine arithmetic
+ * is that small terms whose symbols were shared with other forms will no longer
+ * cancel exactly after absorption.
  *
  * Constructors accept a @ref Threshold tag type to distinguish the threshold
  * parameter from ordinary value parameters and avoid constructor ambiguity.
@@ -84,9 +87,7 @@ public:
      *
      *  @throw none No throw guarantee
      */
-    ThresholdedAffine() :
-      m_lump_term_(affine_t::make_error_term()),
-      m_threshold_(default_threshold().value) {}
+    ThresholdedAffine() : m_threshold_(default_threshold().value) {}
 
     /** @brief Constructs a ThresholdedAffine from a center value.
      *
@@ -125,9 +126,7 @@ public:
      */
     explicit ThresholdedAffine(const interval_t& interval,
                                Threshold t = default_threshold()) :
-      m_affine_(interval),
-      m_lump_term_(affine_t::make_error_term()),
-      m_threshold_(t.value) {
+      m_affine_(interval), m_threshold_(t.value) {
         apply_threshold_();
     }
 
@@ -142,9 +141,7 @@ public:
      */
     ThresholdedAffine(value_t center, error_terms_t radii,
                       Threshold t = default_threshold()) :
-      m_affine_(center, std::move(radii)),
-      m_lump_term_(affine_t::make_error_term()),
-      m_threshold_(t.value) {
+      m_affine_(center, std::move(radii)), m_threshold_(t.value) {
         apply_threshold_();
     }
 
@@ -160,9 +157,7 @@ public:
      *                        Strong throw guarantee.
      */
     ThresholdedAffine(affine_t a, value_t threshold) :
-      m_affine_(std::move(a)),
-      m_lump_term_(affine_t::make_error_term()),
-      m_threshold_(threshold) {
+      m_affine_(std::move(a)), m_threshold_(threshold) {
         apply_threshold_();
     }
 
@@ -331,13 +326,6 @@ public:
      *  @throw none No throw guarantee
      */
     value_t threshold() const { return m_threshold_; }
-
-    /** @brief Returns the lump error symbol.
-     *
-     *  @return The shared error_term_t used for lumped small contributions.
-     *  @throw none No throw guarantee
-     */
-    error_term_t lump_term() const { return m_lump_term_; }
 
     // -- Arithmetic Operators ------------------------------------------------
 
@@ -570,63 +558,40 @@ public:
     }
 
 private:
-    /** @brief Collapses error terms whose relative contribution is below the
-     *         threshold into the persistent lump symbol.
+    /** @brief Replaces error terms below the threshold with fresh symbols.
      *
-     *  After each arithmetic operation, scans all non-lump error terms. Terms
-     *  with @f$|x_i| / \text{total\_radius} < t@f$ are removed and their
-     *  absolute coefficient is added to the lump term's magnitude.
+     *  After each arithmetic operation, scans all error terms. Terms with
+     *  @f$|x_i| / \text{total\_radius} < t@f$ are replaced by a new globally
+     *  unique symbol carrying @f$|x_i|@f$. Because each absorption event
+     *  produces a distinct symbol, absorbed terms from independent sources
+     *  can never cancel each other in subsequent operations.
      */
     void apply_threshold_() {
         if(m_affine_.empty()) return;
         auto total_r = m_affine_.radius();
 
-        // Work on a snapshot to avoid modifying while iterating
         auto terms = m_affine_.error_terms();
-        if(terms.size() == 0) return; // No error terms to threshold
+        if(terms.empty()) return;
 
-        value_t lump_delta          = value_t(0);
-        value_t existing_lump_coeff = value_t(0);
         error_terms_t new_terms;
-
         for(auto&& [sym, coeff] : terms) {
-            if(sym == m_lump_term_) {
-                existing_lump_coeff = coeff;
-                continue;
-            }
             if(std::fabs(coeff) < std::numeric_limits<value_t>::epsilon()) {
-                // Skip zero terms to avoid unnecessary lumping and preserve
-                // sparsity.
                 continue;
             } else if(total_r != value_t(0) &&
                       std::fabs(coeff) / total_r < m_threshold_) {
-                lump_delta += std::fabs(coeff);
+                new_terms[affine_t::make_error_term()] = std::fabs(coeff);
             } else {
                 new_terms[sym] = coeff;
             }
         }
-
-        if(lump_delta > value_t(0) || existing_lump_coeff != value_t(0)) {
-            // Increase |existing_lump_coeff| by lump_delta, preserving sign.
-            // This ensures that if the lump was negated (e.g. via operator-),
-            // cancellation still works when equal forms are subtracted.
-            if(existing_lump_coeff >= value_t(0)) {
-                new_terms[m_lump_term_] = existing_lump_coeff + lump_delta;
-            } else {
-                new_terms[m_lump_term_] = existing_lump_coeff - lump_delta;
-            }
-        }
-
         m_affine_ = affine_t(m_affine_.center(), std::move(new_terms));
     }
 
-    /// The internal affine form holding all error terms (including lump).
+    /// The internal affine form holding all error terms.
     affine_t m_affine_;
 
-    /// Persistent error symbol for aggregated small terms.
-    error_term_t m_lump_term_;
-
-    /// Relative threshold: terms with |x_i| / radius < m_threshold_ are lumped.
+    /// Relative threshold: terms with |x_i| / radius < m_threshold_ are
+    /// replaced.
     value_t m_threshold_;
 };
 

--- a/include/sigma/affine/thresholded_affine.hpp
+++ b/include/sigma/affine/thresholded_affine.hpp
@@ -19,18 +19,23 @@ namespace sigma {
  * unboundedly.
  *
  * This class reduces symbol proliferation by collapsing small error terms into
- * a single persistent "lump" symbol. After each operation, any error term
- * whose relative contribution to the total radius falls below a user-specified
- * threshold @f$t@f$ is folded into the lump:
+ * a non-negative unsigned lump radius @f$R_\ell@f$. After each operation, any
+ * error term whose relative contribution to the total radius falls below a
+ * user-specified threshold @f$t@f$ is folded into the lump:
  * @f[
- *   \frac{|x_i|}{\sum_j |x_j|} < t \implies x_i \text{ is lumped}
+ *   \frac{|x_i|}{\text{total\_radius}} < t \implies |x_i| \text{ is added to }
+ * R_\ell
  * @f]
  *
- * The resulting interval is always a superset of the interval that would be
- * produced by an unthresholded Affine form, so the approach is conservative
- * (sound). The only loss relative to full affine arithmetic is that small
- * dependent error terms that would otherwise cancel may no longer cancel after
- * lumping.
+ * The lump is stored as a plain non-negative radius, not as a signed affine
+ * coefficient. It always contributes @f$+R_\ell@f$ to the total radius and is
+ * combined by addition in both addition and subtraction of two
+ * ThresholdedAffine values. This guarantees that absorbed independent errors
+ * can never cancel against each other.
+ *
+ * The total interval represented is
+ * @f$[\text{center} - \text{radius}(),\, \text{center} + \text{radius}()]@f$
+ * where @f$\text{radius}() = \sum_i |x_i| + R_\ell@f$.
  *
  * Constructors accept a @ref Threshold tag type to distinguish the threshold
  * parameter from ordinary value parameters and avoid constructor ambiguity.
@@ -78,15 +83,12 @@ public:
 
     /** @brief Constructs an empty ThresholdedAffine.
      *
-     *  The resulting ThresholdedAffine represents the empty set. The lump term
-     *  is initialized but has zero radius, and the threshold is set to the
-     *  default value.
+     *  The resulting ThresholdedAffine represents the empty set. The lump
+     *  radius is zero and the threshold is set to the default value.
      *
      *  @throw none No throw guarantee
      */
-    ThresholdedAffine() :
-      m_lump_term_(affine_t::make_error_term()),
-      m_threshold_(default_threshold().value) {}
+    ThresholdedAffine() : m_threshold_(default_threshold().value) {}
 
     /** @brief Constructs a ThresholdedAffine from a center value.
      *
@@ -125,9 +127,7 @@ public:
      */
     explicit ThresholdedAffine(const interval_t& interval,
                                Threshold t = default_threshold()) :
-      m_affine_(interval),
-      m_lump_term_(affine_t::make_error_term()),
-      m_threshold_(t.value) {
+      m_affine_(interval), m_threshold_(t.value) {
         apply_threshold_();
     }
 
@@ -142,26 +142,27 @@ public:
      */
     ThresholdedAffine(value_t center, error_terms_t radii,
                       Threshold t = default_threshold()) :
-      m_affine_(center, std::move(radii)),
-      m_lump_term_(affine_t::make_error_term()),
-      m_threshold_(t.value) {
+      m_affine_(center, std::move(radii)), m_threshold_(t.value) {
         apply_threshold_();
     }
 
     /** @brief Constructs a ThresholdedAffine by wrapping an Affine form.
      *
      *  Used internally by operations that produce an Affine result and need to
-     *  re-wrap it as a ThresholdedAffine.
+     *  re-wrap it as a ThresholdedAffine, optionally carrying an existing lump
+     *  radius.
      *
-     *  @param[in] a         The Affine form to wrap.
-     *  @param[in] threshold The relative threshold.
+     *  @param[in] a            The Affine form to wrap.
+     *  @param[in] threshold    The relative threshold.
+     *  @param[in] lump_radius  Initial non-negative lump radius to carry over.
      *
      *  @throw std::bad_alloc If memory allocation for the error term fails.
      *                        Strong throw guarantee.
      */
-    ThresholdedAffine(affine_t a, value_t threshold) :
+    ThresholdedAffine(affine_t a, value_t threshold,
+                      value_t lump_radius = value_t(0)) :
       m_affine_(std::move(a)),
-      m_lump_term_(affine_t::make_error_term()),
+      m_lump_radius_(lump_radius),
       m_threshold_(threshold) {
         apply_threshold_();
     }
@@ -207,21 +208,24 @@ public:
 
     /** @brief Returns the default threshold value.
      *
-     *  This is a state method that ensures the default threshold is defined
-     *  in a single place and can be easily changed if needed. The default
-     *  threshold is currently set to 0.01 (1%).
-     *
-     *  @return The default threshold.
+     *  @return The default threshold (1%).
      *  @throw none No throw guarantee
      */
     static constexpr Threshold default_threshold() { return Threshold(0.01); }
 
     /** @brief Returns the interval represented by *this.
      *
-     *  @return The interval [center - radius, center + radius].
+     *  The interval is [center - radius(), center + radius()], where radius()
+     *  includes both the tracked affine terms and the unsigned lump radius.
+     *
+     *  @return The interval.
      *  @throw none No throw guarantee
      */
-    interval_t range() const { return m_affine_.range(); }
+    interval_t range() const {
+        if(m_affine_.empty()) return interval_t{};
+        auto r = m_affine_.radius() + m_lump_radius_;
+        return interval_t(m_affine_.center() - r, m_affine_.center() + r);
+    }
 
     /** @brief Returns the center of the affine form.
      *
@@ -230,19 +234,28 @@ public:
      */
     value_t center() const { return m_affine_.center(); }
 
-    /** @brief Returns the error terms, including the lump term.
+    /** @brief Returns the error terms of the tracked affine form.
+     *
+     *  Does not include the unsigned lump radius; use lump_radius() for that.
      *
      *  @return Const reference to the error terms map.
      *  @throw None No throw guarantee.
      */
     const error_terms_t& error_terms() const { return m_affine_.error_terms(); }
 
-    /** @brief Returns the sum of absolute values of all error term radii.
+    /** @brief Returns the total radius: sum of tracked terms plus lump radius.
      *
-     *  @return The radius.
+     *  @return The total radius.
      *  @throw std::domain_error If *this is empty.
      */
-    value_t radius() const { return m_affine_.radius(); }
+    value_t radius() const { return m_affine_.radius() + m_lump_radius_; }
+
+    /** @brief Returns the unsigned lump radius accumulated so far.
+     *
+     *  @return Non-negative lump radius.
+     *  @throw none No throw guarantee.
+     */
+    value_t lump_radius() const { return m_lump_radius_; }
 
     /** @brief Sets the center of the affine form.
      *
@@ -268,7 +281,7 @@ public:
      *  @return True if the value is in range().
      *  @throw none No throw guarantee
      */
-    bool contains(value_t v) const { return m_affine_.contains(v); }
+    bool contains(value_t v) const { return range().contains(v); }
 
     /** @brief Returns whether *this contains an interval.
      *
@@ -276,7 +289,7 @@ public:
      *  @return True if every point in @p i is in range().
      *  @throw none No throw guarantee
      */
-    bool contains(const interval_t& i) const { return m_affine_.contains(i); }
+    bool contains(const interval_t& i) const { return range().contains(i); }
 
     /** @brief Returns whether *this contains another ThresholdedAffine's range.
      *
@@ -285,7 +298,7 @@ public:
      *  @throw none No throw guarantee
      */
     bool contains(const ThresholdedAffine& other) const {
-        return m_affine_.contains(other.m_affine_.range());
+        return range().contains(other.range());
     }
 
     /** @brief Returns whether *this is empty.
@@ -295,7 +308,7 @@ public:
      */
     bool empty() const noexcept { return m_affine_.empty(); }
 
-    /** @brief Returns a string of the affine form.
+    /** @brief Returns a string of the affine form (tracked terms only).
      *
      *  @return Affine form string.
      *  @throw std::bad_alloc If memory allocation for the string fails.
@@ -307,17 +320,14 @@ public:
 
     /** @brief Returns a string of the interval form.
      *
-     *  @return Interval form string, e.g. [lo, hi].
+     *  @return Interval form string, e.g. [lo, hi], including the lump.
      *  @throw std::bad_alloc
      */
     std::string print_interval_form() const {
-        return m_affine_.print_interval_form();
+        return range().print_interval_form();
     }
 
-    /** @brief Returns the underlying Affine form (read-only).
-     *
-     *  Used by operations that need to call Affine-specific functions (e.g.
-     *  apply_affine_transform) and then re-wrap the result.
+    /** @brief Returns the underlying Affine form (tracked terms only).
      *
      *  @return Const reference to the internal Affine form.
      *  @throw none No throw guarantee
@@ -326,25 +336,17 @@ public:
 
     /** @brief Returns the relative threshold.
      *
-     *  @return The threshold @f$t@f$ such that terms with
-     *          @f$|x_i|/\text{radius} < t@f$ are lumped.
+     *  @return The threshold @f$t@f$.
      *  @throw none No throw guarantee
      */
     value_t threshold() const { return m_threshold_; }
-
-    /** @brief Returns the lump error symbol.
-     *
-     *  @return The shared error_term_t used for lumped small contributions.
-     *  @throw none No throw guarantee
-     */
-    error_term_t lump_term() const { return m_lump_term_; }
 
     // -- Arithmetic Operators ------------------------------------------------
 
     /** @brief Returns the additive inverse of *this.
      *
-     *  Negation preserves relative error-term magnitudes, so no re-thresholding
-     *  is needed.
+     *  Negation flips the tracked affine terms; the unsigned lump radius is
+     *  unchanged because it represents a magnitude, not a signed coefficient.
      *
      *  @return The negated ThresholdedAffine.
      *  @throw std::bad_alloc If memory allocation fails.
@@ -352,6 +354,7 @@ public:
     ThresholdedAffine operator-() const {
         auto result      = *this;
         result.m_affine_ = -m_affine_;
+        // m_lump_radius_ is unsigned; it does not negate.
         return result;
     }
 
@@ -368,34 +371,27 @@ public:
 
     /** @brief Adds another ThresholdedAffine to *this.
      *
+     *  The tracked affine terms are combined with normal affine addition
+     *  (shared symbols may cancel). The lump radii are added unconditionally
+     *  because they represent unsigned independent uncertainty.
+     *
      *  @param[in] other The form to add.
      *  @return Reference to *this.
      *  @throw None No throw guarantee.
      */
     ThresholdedAffine& operator+=(const ThresholdedAffine& other) {
         m_affine_ += other.m_affine_;
+        m_lump_radius_ += other.m_lump_radius_;
         apply_threshold_();
         return *this;
     }
 
-    /** @brief Returns the sum of *this and a scalar.
-     *
-     *  @param[in] value The scalar to add.
-     *  @return The sum of *this and @p value.
-     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
-     *                        fails. Strong throw guarantee.
-     */
+    /** @brief Returns the sum of *this and a scalar.  */
     ThresholdedAffine operator+(value_t value) const {
         return ThresholdedAffine(*this) += value;
     }
 
-    /** @brief Returns the sum of *this and another ThresholdedAffine.
-     *
-     *  @param[in] other The ThresholdedAffine to add.
-     *  @return The sum of *this and @p other.
-     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
-     *                        fails. Strong throw guarantee.
-     */
+    /** @brief Returns the sum of *this and another ThresholdedAffine.  */
     ThresholdedAffine operator+(const ThresholdedAffine& other) const {
         return ThresholdedAffine(*this) += other;
     }
@@ -413,39 +409,35 @@ public:
 
     /** @brief Subtracts another ThresholdedAffine from *this.
      *
+     *  Tracked affine terms are combined with normal affine subtraction
+     *  (shared symbols cancel, capturing dependency). The lump radii are
+     *  *added* — not subtracted — because the lump is an unsigned bound on
+     *  independent accumulated errors that cannot cancel.
+     *
      *  @param[in] other The form to subtract.
      *  @return Reference to *this.
      *  @throw None No throw guarantee.
      */
     ThresholdedAffine& operator-=(const ThresholdedAffine& other) {
         m_affine_ -= other.m_affine_;
+        m_lump_radius_ += other.m_lump_radius_;
         apply_threshold_();
         return *this;
     }
 
-    /** @brief Returns the difference of *this and a scalar.
-     *
-     *  @param[in] value The scalar to subtract.
-     *  @return The difference of *this and @p value.
-     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
-     *                        fails. Strong throw guarantee.
-     */
+    /** @brief Returns the difference of *this and a scalar.  */
     ThresholdedAffine operator-(value_t value) const {
         return ThresholdedAffine(*this) -= value;
     }
 
-    /** @brief Returns the difference of *this and another ThresholdedAffine.
-     *
-     *  @param[in] other The ThresholdedAffine to subtract.
-     *  @return The difference of *this and @p other.
-     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
-     *                        fails. Strong throw guarantee.
-     */
+    /** @brief Returns the difference of *this and another ThresholdedAffine. */
     ThresholdedAffine operator-(const ThresholdedAffine& other) const {
         return ThresholdedAffine(*this) -= other;
     }
 
     /** @brief Multiplies *this by a scalar.
+     *
+     *  The lump radius is scaled by @p |value|.
      *
      *  @param[in] value The scalar to multiply by.
      *  @return Reference to *this.
@@ -453,44 +445,51 @@ public:
      */
     ThresholdedAffine& operator*=(value_t value) {
         m_affine_ *= value;
+        m_lump_radius_ *= std::fabs(value);
         apply_threshold_();
         return *this;
     }
 
     /** @brief Multiplies *this by another ThresholdedAffine.
      *
-     *  Multiplication introduces a new nonlinearity error term; thresholding
-     *  is applied afterward so that small terms (including the new one, if its
-     *  relative contribution is negligible) are folded into the lump.
+     *  Multiplication introduces a new nonlinearity error term via affine
+     *  arithmetic, plus contributions from each operand's lump radius
+     * interacting with the other operand's affine bound.
      *
      *  @param[in] other The form to multiply by.
      *  @return Reference to *this.
      *  @throw None No throw guarantee.
      */
     ThresholdedAffine& operator*=(const ThresholdedAffine& other) {
+        // Save pre-multiplication bounds needed for lump propagation.
+        value_t a_max = m_affine_.empty() ?
+                          value_t(0) :
+                          std::fabs(m_affine_.center()) + m_affine_.radius();
+        value_t b_max =
+          other.m_affine_.empty() ?
+            value_t(0) :
+            std::fabs(other.m_affine_.center()) + other.m_affine_.radius();
+        value_t a_lump = m_lump_radius_;
+        value_t b_lump = other.m_lump_radius_;
+
         m_affine_ *= other.m_affine_;
+
+        // Lump contributions from the product:
+        //   a_affine × b_lump  bounded by a_max × b_lump
+        //   a_lump × b_affine  bounded by a_lump × b_max
+        //   a_lump × b_lump
+        m_lump_radius_ = a_lump * (b_max + b_lump) + a_max * b_lump;
+
         apply_threshold_();
         return *this;
     }
 
-    /** @brief Multiplies *this by a scalar.
-     *
-     *  @param[in] value The scalar to multiply by.
-     *  @return The product of *this and @p value.
-     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
-     *                        fails. Strong throw guarantee.
-     */
+    /** @brief Multiplies *this by a scalar.  */
     ThresholdedAffine operator*(value_t value) const {
         return ThresholdedAffine(*this) *= value;
     }
 
-    /** @brief Multiplies *this by another ThresholdedAffine.
-     *
-     *  @param[in] other The ThresholdedAffine to multiply by.
-     *  @return The product of *this and @p other.
-     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
-     *                        fails. Strong throw guarantee.
-     */
+    /** @brief Multiplies *this by another ThresholdedAffine.  */
     ThresholdedAffine operator*(const ThresholdedAffine& other) const {
         return ThresholdedAffine(*this) *= other;
     }
@@ -503,42 +502,54 @@ public:
      */
     ThresholdedAffine& operator/=(value_t value) {
         m_affine_ /= value;
+        m_lump_radius_ /= std::fabs(value);
         apply_threshold_();
         return *this;
     }
 
     /** @brief Divides *this by another ThresholdedAffine.
      *
+     *  The lump radius of the divisor expands its interval, contributing
+     *  additional uncertainty to the quotient.  A conservative bound is used:
+     *  the divisor's full interval (affine ± lump) determines the minimum
+     *  absolute value @f$b_\min@f$ used to scale the result's lump.
+     *
      *  @param[in] other The form to divide by.
      *  @return Reference to *this.
-     *  @throw std::domain_error If @p other is empty or contains zero.
+     *  @throw std::domain_error If @p other is empty or its full interval
+     *                           contains zero.
      */
     ThresholdedAffine& operator/=(const ThresholdedAffine& other) {
+        // Minimum absolute value of other over its full interval (affine +
+        // lump).
+        value_t other_total = other.m_affine_.radius() + other.m_lump_radius_;
+        value_t b_min       = std::fabs(other.m_affine_.center()) - other_total;
+        if(b_min <= value_t(0)) {
+            throw std::domain_error(
+              "ThresholdedAffine division by interval containing zero");
+        }
+
+        value_t pre_lump = m_lump_radius_;
+
         m_affine_ /= other.m_affine_;
+
+        // this's lump scaled by 1/|b_min|, plus additional uncertainty from
+        // other's lump acting on the result: result_bound × b_lump / b_min.
+        value_t result_bound =
+          std::fabs(m_affine_.center()) + m_affine_.radius() + m_lump_radius_;
+        m_lump_radius_ =
+          pre_lump / b_min + result_bound * other.m_lump_radius_ / b_min;
+
         apply_threshold_();
         return *this;
     }
 
-    /** @brief Divides *this by a scalar.
-     *
-     *  @param[in] value The scalar to divide by.
-     *  @return The quotient of *this and @p value.
-     *  @throw std::domain_error If @p value is zero.
-     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
-     *                        fails. Strong throw guarantee.
-     */
+    /** @brief Divides *this by a scalar.  */
     ThresholdedAffine operator/(value_t value) const {
         return ThresholdedAffine(*this) /= value;
     }
 
-    /** @brief Divides *this by another ThresholdedAffine.
-     *
-     *  @param[in] other The ThresholdedAffine to divide by.
-     *  @return The quotient of *this and @p other.
-     *  @throw std::domain_error If @p other is empty or contains zero.
-     *  @throw std::bad_alloc If memory allocation for the new ThresholdedAffine
-     *                        fails. Strong throw guarantee.
-     */
+    /** @brief Divides *this by another ThresholdedAffine.  */
     ThresholdedAffine operator/(const ThresholdedAffine& other) const {
         return ThresholdedAffine(*this) /= other;
     }
@@ -547,15 +558,13 @@ public:
 
     /** @brief Checks equality of two ThresholdedAffine forms.
      *
-     *  Two ThresholdedAffine forms are equal if they have the same internal
-     *  Affine form and the same threshold.
-     *
      *  @param[in] other The form to compare.
      *  @return True if equal.
      *  @throw none No throw guarantee.
      */
     bool operator==(const ThresholdedAffine& other) const {
         return m_affine_ == other.m_affine_ &&
+               m_lump_radius_ == other.m_lump_radius_ &&
                m_threshold_ == other.m_threshold_;
     }
 
@@ -570,63 +579,43 @@ public:
     }
 
 private:
-    /** @brief Collapses error terms whose relative contribution is below the
-     *         threshold into the persistent lump symbol.
+    /** @brief Absorbs error terms below the relative threshold into the
+     *         unsigned lump radius.
      *
-     *  After each arithmetic operation, scans all non-lump error terms. Terms
-     *  with @f$|x_i| / \text{total\_radius} < t@f$ are removed and their
-     *  absolute coefficient is added to the lump term's magnitude.
+     *  After each arithmetic operation, scans all error terms in m_affine_.
+     *  Terms with @f$|x_i| / \text{total\_radius} < t@f$ are removed and
+     *  their absolute coefficient is added to @p m_lump_radius_.
+     *  total_radius includes the existing lump radius.
      */
     void apply_threshold_() {
         if(m_affine_.empty()) return;
-        auto total_r = m_affine_.radius();
+        auto total_r = m_affine_.radius() + m_lump_radius_;
 
-        // Work on a snapshot to avoid modifying while iterating
         auto terms = m_affine_.error_terms();
-        if(terms.size() == 0) return; // No error terms to threshold
+        if(terms.empty()) return;
 
-        value_t lump_delta          = value_t(0);
-        value_t existing_lump_coeff = value_t(0);
         error_terms_t new_terms;
-
         for(auto&& [sym, coeff] : terms) {
-            if(sym == m_lump_term_) {
-                existing_lump_coeff = coeff;
-                continue;
-            }
             if(std::fabs(coeff) < std::numeric_limits<value_t>::epsilon()) {
-                // Skip zero terms to avoid unnecessary lumping and preserve
-                // sparsity.
                 continue;
             } else if(total_r != value_t(0) &&
                       std::fabs(coeff) / total_r < m_threshold_) {
-                lump_delta += std::fabs(coeff);
+                m_lump_radius_ += std::fabs(coeff);
             } else {
                 new_terms[sym] = coeff;
             }
         }
-
-        if(lump_delta > value_t(0) || existing_lump_coeff != value_t(0)) {
-            // Increase |existing_lump_coeff| by lump_delta, preserving sign.
-            // This ensures that if the lump was negated (e.g. via operator-),
-            // cancellation still works when equal forms are subtracted.
-            if(existing_lump_coeff >= value_t(0)) {
-                new_terms[m_lump_term_] = existing_lump_coeff + lump_delta;
-            } else {
-                new_terms[m_lump_term_] = existing_lump_coeff - lump_delta;
-            }
-        }
-
         m_affine_ = affine_t(m_affine_.center(), std::move(new_terms));
     }
 
-    /// The internal affine form holding all error terms (including lump).
+    /// The tracked affine form (does not contain the lump).
     affine_t m_affine_;
 
-    /// Persistent error symbol for aggregated small terms.
-    error_term_t m_lump_term_;
+    /// Non-negative accumulated radius for absorbed small terms.
+    value_t m_lump_radius_{value_t(0)};
 
-    /// Relative threshold: terms with |x_i| / radius < m_threshold_ are lumped.
+    /// Relative threshold: terms with |x_i| / total_radius < m_threshold_ are
+    /// lumped.
     value_t m_threshold_;
 };
 
@@ -656,16 +645,18 @@ ThresholdedAffine<ValueType> operator*(ValueType value,
 }
 
 // -- Operations --------------------------------------------------------------
-// These delegate to the corresponding Affine operations and re-wrap the result.
 
 /** @brief Absolute value of a ThresholdedAffine.
+ *
+ *  The lump radius is unchanged (abs is Lipschitz-1).
  *
  *  @related ThresholdedAffine
  *  @tparam T The value type.
  */
 template<typename T>
 ThresholdedAffine<T> abs(const ThresholdedAffine<T>& a) {
-    return ThresholdedAffine<T>(abs(a.affine()), a.threshold());
+    return ThresholdedAffine<T>(abs(a.affine()), a.threshold(),
+                                a.lump_radius());
 }
 
 /** @brief Absolute value of a ThresholdedAffine (alias for abs).
@@ -675,10 +666,15 @@ ThresholdedAffine<T> abs(const ThresholdedAffine<T>& a) {
  */
 template<typename T>
 ThresholdedAffine<T> fabs(const ThresholdedAffine<T>& a) {
-    return ThresholdedAffine<T>(fabs(a.affine()), a.threshold());
+    return ThresholdedAffine<T>(fabs(a.affine()), a.threshold(),
+                                a.lump_radius());
 }
 
 /** @brief Square root of a ThresholdedAffine.
+ *
+ *  The lump is propagated by the Lipschitz constant of sqrt over a's range:
+ *  @f$1 / (2 \sqrt{x_\min})@f$ where @f$x_\min@f$ is the lower bound of a's
+ *  full interval.
  *
  *  @related ThresholdedAffine
  *  @tparam T The value type.
@@ -686,20 +682,32 @@ ThresholdedAffine<T> fabs(const ThresholdedAffine<T>& a) {
  */
 template<typename T>
 ThresholdedAffine<T> sqrt(const ThresholdedAffine<T>& a) {
-    return ThresholdedAffine<T>(sqrt(a.affine()), a.threshold());
+    T x_min = a.center() - a.radius();
+    T lip   = x_min > T(0) ? T(1) / (T(2) * std::sqrt(x_min)) : T(1);
+    return ThresholdedAffine<T>(sqrt(a.affine()), a.threshold(),
+                                a.lump_radius() * lip);
 }
 
 /** @brief Exponential of a ThresholdedAffine.
+ *
+ *  The lump is propagated by the Lipschitz constant of exp over a's range:
+ *  @f$\exp(x_\max)@f$ where @f$x_\max@f$ is the upper bound of a's full
+ *  interval.
  *
  *  @related ThresholdedAffine
  *  @tparam T The value type.
  */
 template<typename T>
 ThresholdedAffine<T> exp(const ThresholdedAffine<T>& a) {
-    return ThresholdedAffine<T>(exp(a.affine()), a.threshold());
+    T x_max = a.center() + a.radius();
+    return ThresholdedAffine<T>(exp(a.affine()), a.threshold(),
+                                a.lump_radius() * std::exp(x_max));
 }
 
 /** @brief Natural logarithm of a ThresholdedAffine.
+ *
+ *  The lump is propagated by the Lipschitz constant of log over a's range:
+ *  @f$1/x_\min@f$ where @f$x_\min@f$ is the lower bound of a's full interval.
  *
  *  @related ThresholdedAffine
  *  @tparam T The value type.
@@ -707,10 +715,16 @@ ThresholdedAffine<T> exp(const ThresholdedAffine<T>& a) {
  */
 template<typename T>
 ThresholdedAffine<T> log(const ThresholdedAffine<T>& a) {
-    return ThresholdedAffine<T>(log(a.affine()), a.threshold());
+    T x_min = a.center() - a.radius();
+    T lip   = x_min > T(0) ? T(1) / x_min : T(1);
+    return ThresholdedAffine<T>(log(a.affine()), a.threshold(),
+                                a.lump_radius() * lip);
 }
 
 /** @brief Power of a ThresholdedAffine.
+ *
+ *  The lump is propagated conservatively using the maximum of @f$|n \cdot
+ *  x^{n-1}|@f$ over a's full interval.
  *
  *  @related ThresholdedAffine
  *  @tparam T The value type.
@@ -719,7 +733,14 @@ ThresholdedAffine<T> log(const ThresholdedAffine<T>& a) {
  */
 template<typename T, typename U>
 ThresholdedAffine<T> pow(const ThresholdedAffine<T>& a, const U& exp) {
-    return ThresholdedAffine<T>(pow(a.affine(), exp), a.threshold());
+    T x_hi = a.center() + a.radius();
+    T x_lo = a.center() - a.radius();
+    // |d(x^n)/dx| = |n| * |x|^(n-1); max over [x_lo, x_hi]
+    T lip = std::fabs(static_cast<T>(exp)) *
+            std::max(std::pow(std::fabs(x_lo), static_cast<T>(exp) - T(1)),
+                     std::pow(std::fabs(x_hi), static_cast<T>(exp) - T(1)));
+    return ThresholdedAffine<T>(pow(a.affine(), exp), a.threshold(),
+                                a.lump_radius() * lip);
 }
 
 /// Typedef for a thresholded affine form of floats

--- a/tests/unit_tests/affine/test_thresholded_affine.cpp
+++ b/tests/unit_tests/affine/test_thresholded_affine.cpp
@@ -110,7 +110,6 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
         REQUIRE(interval.radius() == value_t(0.5));
         REQUIRE_FALSE(interval.empty());
         REQUIRE(interval.threshold() == value_t(0.01));
-        // lump_term() is a size_t ID, always valid (no null concept)
     }
 
     SECTION("Threshold") {
@@ -324,33 +323,53 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
         }
     }
 
-    SECTION("Lump term behavior") {
-        SECTION("Lump term shared across copies (cancellation)") {
-            // When x is copied to y and both have the same lump symbol,
-            // y - x should have a small lump contribution.
-            // With no_lump threshold, no lumping occurs and the cancellation
-            // is exact (as in Affine).
+    SECTION("Absorption soundness") {
+        SECTION("No lumping when threshold is zero") {
+            // With threshold 0, nothing is absorbed: x - x cancels exactly.
             ta_t x(one, two, no_lump);
-            ta_t y    = x; // shares lump symbol via copy
-            ta_t diff = y - x;
+            ta_t diff = x - x;
             REQUIRE(diff.radius() == zero);
         }
 
-        SECTION("Independent forms have distinct lump symbols") {
-            // Two independently created forms with distinct lump symbols
-            // should not cancel their lump contributions.
-            ta_t x(one, two, big_t);
-            ta_t z(one, two, big_t); // fresh construction: new lump symbol
-            // Force some lumping by multiplying
-            x *= ta_t(one, value_t(1.01), big_t);
-            z *= ta_t(one, value_t(1.01), big_t);
-            // x and z are independent — their difference should NOT be zero
-            // (the lump symbols differ).
-            // We just verify the forms are conservative.
-            affine_t ax(one, two), az(one, two);
-            affine_t ax2(one, value_t(1.01)), az2(one, value_t(1.01));
-            contains_affine_range(x, ax * ax2);
-            contains_affine_range(z, az * az2);
+        SECTION("Absorbed terms from independent sources never cancel") {
+            // This tests that the fresh-symbol-per-absorption design is sound.
+            // The old single-symbol design had a bug where absorbed independent
+            // errors could subtract rather than add:
+            //
+            //   a has {sym1: R, sym2: ds} where sym2/total < threshold →
+            //   absorbed b = a (copy), then scaled and augmented with an
+            //   independent error c a - b: with a shared lump symbol, c's
+            //   absorbed contribution subtracted from a's lump instead of
+            //   adding, giving a radius smaller than the plain Affine radius —
+            //   an unsound result.
+            //
+            // With fresh symbols each absorption is independent, so no such
+            // cancellation can occur.
+
+            const value_t R     = value_t(1.0);
+            const value_t ds    = value_t(0.05);
+            const value_t alpha = value_t(0.9);
+            const value_t dn    = value_t(0.03);
+            const threshold_t T{value_t(0.1)};
+
+            auto sym1 = affine_t::make_error_term();
+            auto sym2 = affine_t::make_error_term();
+
+            ta_t a(value_t(2.5),
+                   typename ta_t::error_terms_t{{sym1, R}, {sym2, ds}}, T);
+            ta_t b = a;
+            b *= alpha;
+            ta_t c(-dn, dn, T);
+            b += c;
+            ta_t diff_ta = a - b;
+
+            affine_t a_af(value_t(2.5), {{sym1, R}, {sym2, ds}});
+            affine_t b_af = a_af * alpha;
+            affine_t c_af(-dn, dn);
+            affine_t diff_af = a_af - (b_af + c_af);
+
+            REQUIRE(diff_ta.radius() >= diff_af.radius());
+            REQUIRE(diff_ta.contains(diff_af.range()));
         }
     }
 }

--- a/tests/unit_tests/affine/test_thresholded_affine.cpp
+++ b/tests/unit_tests/affine/test_thresholded_affine.cpp
@@ -110,7 +110,7 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
         REQUIRE(interval.radius() == value_t(0.5));
         REQUIRE_FALSE(interval.empty());
         REQUIRE(interval.threshold() == value_t(0.01));
-        // lump_term() is a size_t ID, always valid (no null concept)
+        REQUIRE(interval.lump_radius() == value_t(0));
     }
 
     SECTION("Threshold") {
@@ -324,33 +324,105 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
         }
     }
 
-    SECTION("Lump term behavior") {
-        SECTION("Lump term shared across copies (cancellation)") {
-            // When x is copied to y and both have the same lump symbol,
-            // y - x should have a small lump contribution.
-            // With no_lump threshold, no lumping occurs and the cancellation
-            // is exact (as in Affine).
+    SECTION("Lump radius behavior") {
+        SECTION("No lumping when threshold is zero") {
+            // With no_lump threshold the lump radius stays zero and x - x
+            // cancels exactly (all error terms are tracked symbols).
             ta_t x(one, two, no_lump);
-            ta_t y    = x; // shares lump symbol via copy
+            ta_t y    = x;
             ta_t diff = y - x;
             REQUIRE(diff.radius() == zero);
+            REQUIRE(diff.lump_radius() == zero);
         }
 
-        SECTION("Independent forms have distinct lump symbols") {
-            // Two independently created forms with distinct lump symbols
-            // should not cancel their lump contributions.
+        SECTION("Lump radius accumulates after lumping") {
+            // With big_t, small nonlinearity terms are absorbed into the
+            // unsigned lump radius.
             ta_t x(one, two, big_t);
-            ta_t z(one, two, big_t); // fresh construction: new lump symbol
-            // Force some lumping by multiplying
-            x *= ta_t(one, value_t(1.01), big_t);
-            z *= ta_t(one, value_t(1.01), big_t);
-            // x and z are independent — their difference should NOT be zero
-            // (the lump symbols differ).
-            // We just verify the forms are conservative.
-            affine_t ax(one, two), az(one, two);
-            affine_t ax2(one, value_t(1.01)), az2(one, value_t(1.01));
-            contains_affine_range(x, ax * ax2);
-            contains_affine_range(z, az * az2);
+            ta_t bump(one, value_t(1.01), big_t);
+            x *= bump;
+            REQUIRE(x.lump_radius() > zero);
+        }
+
+        SECTION("Lump radii add in subtraction (no cancellation)") {
+            // With big_t, both x and y have non-zero lump radii after
+            // multiplication. Their difference has lump ≥ x.lump + y.lump
+            // because unsigned lumps always add.
+            ta_t x(one, two, big_t);
+            ta_t bump(one, value_t(1.01), big_t);
+            x *= bump;
+            ta_t y    = x; // copy, same lump radius value
+            ta_t diff = x - y;
+            REQUIRE(diff.lump_radius() >= x.lump_radius() + y.lump_radius());
+        }
+
+        SECTION("Signed lump can produce interval smaller than true range") {
+            // This test proved that the first implementation using signed lump
+            // violates the upper-bound guarantee. The root cause:
+            //
+            //   The copy constructor shares m_lump_term_ between a and its
+            //   copy b.  When an independent error is absorbed into the shared
+            //   lump of b (because it falls below the relative threshold), and
+            //   then a - b is computed, that absorbed error SUBTRACTS from the
+            //   shared lump contribution instead of ADDING to the radius.
+            //
+            // Concrete trace:
+            //   a: center=2.5, {sym1: R=1.0, L_a: ds=0.05}
+            //      (sym2 with coeff ds was lumped on construction because
+            //       ds/(R+ds) = 0.048 < threshold=0.10)
+            //   b = a (copy, shares L_a), then scaled by alpha=0.9:
+            //      b: {sym1: 0.9, L_a: 0.045}
+            //   c = [-dn, dn] = [-0.03, 0.03] independent error; its single
+            //      term has relative contribution dn/0.975 ≈ 0.031 < 0.10 →
+            //      absorbed into L_a when b += c:
+            //      b: {sym1: 0.9, L_a: 0.075}
+            //   diff = a - b:
+            //      L_a coeff: 0.05 - 0.075 = -0.025 → |contrib| = 0.025
+            //      sym1 coeff: 1.0 - 0.9   =  0.100 → |contrib| = 0.100
+            //      ThresholdedAffine radius = 0.125
+            //
+            // Plain Affine (sym2 and ε_c tracked separately):
+            //   diff: {sym1: 0.10, sym2: 0.005, ε_c: -0.03} → radius = 0.135
+            //
+            // The independent error dn=0.03 cancelled (net -0.025) instead of
+            // contributing +0.03, giving 0.125 < 0.135.  The true extremal
+            // value (sym2 and ε_c extremised in opposite directions) lies
+            // outside the ThresholdedAffine interval.
+
+            const value_t R  = value_t(1.0);
+            const value_t ds = value_t(0.05); // lumped: 0.05/1.05 ≈ 4.8% < 10%
+            const value_t alpha = value_t(0.9);
+            const value_t dn =
+              value_t(0.03); // lumped into b: 0.03/0.975 ≈ 3.1% < 10%
+            const threshold_t T{value_t(0.1)};
+
+            auto sym1 = affine_t::make_error_term();
+            auto sym2 = affine_t::make_error_term();
+
+            // ThresholdedAffine path: sym2 is lumped into L_a on construction.
+            ta_t a_ta(value_t(2.5),
+                      typename ta_t::error_terms_t{{sym1, R}, {sym2, ds}}, T);
+            ta_t b_ta = a_ta;      // copy — shares lump symbol L_a
+            b_ta *= alpha;         // {sym1: 0.9, L_a: 0.045}
+            ta_t c_ta(-dn, dn, T); // single-term interval; not lumped within c
+            b_ta += c_ta;          // c's term absorbed into shared L_a → 0.075
+            ta_t diff_ta = a_ta - b_ta;
+
+            // Plain Affine path: every term tracked individually, no lumping.
+            affine_t a_af(value_t(2.5), {{sym1, R}, {sym2, ds}});
+            affine_t b_af = a_af * alpha;
+            affine_t c_af(-dn, dn);
+            affine_t diff_af = a_af - (b_af + c_af);
+
+            // After the fix: the unsigned lump never cancels, so the
+            // ThresholdedAffine radius is at least as large as the plain Affine
+            // radius (it may be larger because the lump from a and the lump
+            // from b both add, even though the sym2 part is correlated).
+            REQUIRE(diff_ta.radius() >= diff_af.radius());
+
+            // The ThresholdedAffine interval contains the correct range,
+            // satisfying the upper-bound guarantee.
+            REQUIRE(diff_ta.contains(diff_af.range()));
         }
     }
 }

--- a/tests/unit_tests/affine/test_thresholded_affine.cpp
+++ b/tests/unit_tests/affine/test_thresholded_affine.cpp
@@ -10,7 +10,8 @@ using TAFloat  = sigma::TAFloat;
 using TADouble = sigma::TADouble;
 
 // Helper: verify that a ThresholdedAffine's range contains the equivalent
-// Affine range. Used to assert conservatism.
+// Affine range. Note that dropping terms is not conservative in general; this
+// holds only when nothing significant is dropped (small thresholds / inputs).
 template<typename TA>
 void contains_affine_range(const TA& ta,
                            const sigma::Affine<typename TA::value_t>& a) {
@@ -30,11 +31,11 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
     const value_t three = value_t(3.0);
     const value_t four  = value_t(4.0);
 
-    // A threshold low enough that single-term forms never get lumped.
-    const threshold_t no_lump{value_t(0.0)};
-    // A threshold high enough to lump almost everything.
+    // A threshold of zero so that no error terms are ever dropped.
+    const threshold_t no_drop{value_t(0.0)};
+    // A threshold high enough to drop almost everything.
     const threshold_t big_t{value_t(0.5)};
-    // The default threshold (1%).
+    // An explicit threshold of 1% used by several cases below.
     const threshold_t def_t{value_t(0.01)};
 
     SECTION("Constructors") {
@@ -109,16 +110,14 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
         REQUIRE(interval.center() == value_t(1.5));
         REQUIRE(interval.radius() == value_t(0.5));
         REQUIRE_FALSE(interval.empty());
-        REQUIRE(interval.threshold() == value_t(0.01));
-        REQUIRE(interval.lump_radius() == value_t(0));
+        REQUIRE(interval.threshold() == value_t(0.001));
     }
 
     SECTION("Threshold") {
-        SECTION("No lumping for a single-term form") {
-            // A single-term form has relative contribution 1.0, never lumped.
+        SECTION("No dropping for a single-term form") {
+            // A single-term form has relative contribution 1.0, never dropped.
             ta_t x(one, two, def_t);
             // Should have exactly one error term (the interval's epsilon).
-            // The lump term should NOT be present (or have zero coefficient).
             auto terms = x.error_terms();
             // Count non-zero terms
             std::size_t nonzero = 0;
@@ -128,11 +127,11 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
             REQUIRE(nonzero == 1);
         }
 
-        SECTION("Lumping reduces term count after multiplication") {
+        SECTION("Dropping reduces term count after multiplication") {
             // x in [1, 2], y in [1, 2] — multiply to get nonlinearity term.
             // With a tight threshold the nonlinearity correction (0.25) is
-            // small relative to the main terms (~0.5 each), so it may be
-            // lumped at threshold > ~0.2.
+            // small relative to the main terms (~0.5 each), so it is dropped
+            // at threshold > ~0.2.
             ta_t x(one, two, big_t);
             ta_t y(one, two, big_t);
             ta_t z = x * y;
@@ -141,33 +140,29 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
             affine_t ax(one, two), ay(one, two);
             affine_t az = ax * ay;
 
-            // ThresholdedAffine result must contain the Affine result.
-            contains_affine_range(z, az);
-
-            // With big threshold, the new nonlinearity term is likely lumped.
-            // Verify that z has fewer unique symbols than az (or at most
-            // equal).
+            // With a big threshold the new nonlinearity term is dropped, so z
+            // has no more unique symbols than az.
             REQUIRE(z.error_terms().size() <= az.error_terms().size());
         }
 
-        SECTION("Lumped lump term grows monotonically") {
+        SECTION("Dropping keeps the term count bounded") {
             // Start with [1, 2] and multiply repeatedly; each multiplication
-            // adds a nonlinearity term.  With a high threshold, these get
-            // absorbed into the lump, so the total term count stays small.
+            // adds a nonlinearity term.  With a high threshold, these are
+            // dropped, so the total term count stays small.
             ta_t x(one, two, big_t);
             std::size_t prev_count = x.error_terms().size();
             for(int i = 0; i < 5; ++i) {
                 ta_t bump(value_t(1.0), value_t(1.01), big_t);
                 x *= bump;
                 // Symbol count should stay bounded (≤ prev + 1 at most,
-                // and often stays the same due to lumping).
+                // and often stays the same because terms are dropped).
                 REQUIRE(x.error_terms().size() <= prev_count + 2);
                 prev_count = x.error_terms().size();
             }
         }
     }
 
-    SECTION("Conservatism: range always contains Affine range") {
+    SECTION("range contains Affine range when nothing significant is dropped") {
         affine_t ax(one, two), ay(two, three);
         ta_t tx(one, two, def_t), ty(two, three, def_t);
 
@@ -193,49 +188,49 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
 
     SECTION("Arithmetic") {
         SECTION("Scalar add") {
-            ta_t x(one, two, no_lump);
+            ta_t x(one, two, no_drop);
             x += two;
             test_affine(x, three, four);
         }
 
         SECTION("Scalar subtract") {
-            ta_t x(one, two, no_lump);
+            ta_t x(one, two, no_drop);
             x -= one;
             test_affine(x, zero, one);
         }
 
         SECTION("Scalar multiply") {
-            ta_t x(one, two, no_lump);
+            ta_t x(one, two, no_drop);
             x *= two;
             test_affine(x, two, four);
         }
 
         SECTION("Scalar divide") {
-            ta_t x(two, four, no_lump);
+            ta_t x(two, four, no_drop);
             x /= two;
             test_affine(x, one, two);
         }
 
         SECTION("Affine add") {
-            ta_t x(one, two, no_lump), y(two, three, no_lump);
+            ta_t x(one, two, no_drop), y(two, three, no_drop);
             test_affine(x + y, three, value_t(5.0));
         }
 
         SECTION("Unary minus") {
-            ta_t x(one, two, no_lump);
+            ta_t x(one, two, no_drop);
             test_affine(-x, -two, -one);
         }
 
         SECTION("Dependent subtraction: x - x") {
-            // With no_lump, x shares its error symbol with its copy, so
-            // x - x = 0 exactly (same as Affine).
-            ta_t x(one, two, no_lump);
+            // With no_drop, no terms are dropped, so x shares its error symbol
+            // with its copy and x - x = 0 exactly (same as Affine).
+            ta_t x(one, two, no_drop);
             ta_t result = x - x;
             REQUIRE(result.radius() == zero);
         }
 
         SECTION("Scalar right multiply") {
-            ta_t x(one, two, no_lump);
+            ta_t x(one, two, no_drop);
             ta_t result = two * x;
             test_affine(result, two, four);
         }
@@ -251,7 +246,7 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
     }
 
     SECTION("Contains") {
-        ta_t x(one, two, no_lump);
+        ta_t x(one, two, no_drop);
         REQUIRE(x.contains(one));
         REQUIRE(x.contains(two));
         REQUIRE(x.contains(value_t(1.5)));
@@ -262,9 +257,9 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
         REQUIRE(x.contains(interval_t(one, value_t(1.5))));
         REQUIRE_FALSE(x.contains(interval_t(zero, two)));
 
-        ta_t y(one, value_t(1.5), no_lump);
+        ta_t y(one, value_t(1.5), no_drop);
         REQUIRE(x.contains(y));
-        ta_t z(zero, two, no_lump);
+        ta_t z(zero, two, no_drop);
         REQUIRE_FALSE(x.contains(z));
     }
 
@@ -276,14 +271,14 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
     }
 
     SECTION("Stream output") {
-        ta_t x(one, two, no_lump);
+        ta_t x(one, two, no_drop);
         std::ostringstream os;
         os << x;
         REQUIRE_FALSE(os.str().empty());
     }
 
     SECTION("Operations") {
-        ta_t x(one, two, no_lump);
+        ta_t x(one, two, no_drop);
 
         SECTION("sqrt") {
             test_affine(sigma::sqrt(x), one, value_t(1.43198051533946));
@@ -306,13 +301,13 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
         }
 
         SECTION("abs negative") {
-            ta_t neg(-two, -one, no_lump);
+            ta_t neg(-two, -one, no_drop);
             auto result = sigma::abs(neg);
             test_affine(result, one, two);
         }
 
         SECTION("fabs") {
-            ta_t neg(-two, -one, no_lump);
+            ta_t neg(-two, -one, no_drop);
             auto result = sigma::fabs(neg);
             test_affine(result, one, two);
         }
@@ -324,105 +319,77 @@ TEMPLATE_TEST_CASE("ThresholdedAffine", "", TAFloat, TADouble) {
         }
     }
 
-    SECTION("Lump radius behavior") {
-        SECTION("No lumping when threshold is zero") {
-            // With no_lump threshold the lump radius stays zero and x - x
-            // cancels exactly (all error terms are tracked symbols).
-            ta_t x(one, two, no_lump);
+    SECTION("Dropping behavior") {
+        SECTION("Nothing dropped when threshold is zero") {
+            // With the no_drop threshold every error term is kept, so x - x
+            // cancels exactly (all error terms are shared tracked symbols).
+            ta_t x(one, two, no_drop);
             ta_t y    = x;
             ta_t diff = y - x;
             REQUIRE(diff.radius() == zero);
-            REQUIRE(diff.lump_radius() == zero);
         }
 
-        SECTION("Lump radius accumulates after lumping") {
-            // With big_t, small nonlinearity terms are absorbed into the
-            // unsigned lump radius.
-            ta_t x(one, two, big_t);
-            ta_t bump(one, value_t(1.01), big_t);
-            x *= bump;
-            REQUIRE(x.lump_radius() > zero);
+        SECTION("Sub-threshold terms are discarded") {
+            // sym2's relative contribution is 0.05/1.05 ≈ 4.8%, below the 10%
+            // threshold, so it is dropped on construction. Only sym1 survives
+            // and the radius reflects the kept term alone.
+            const threshold_t T{value_t(0.1)};
+            auto sym1 = affine_t::make_error_term();
+            auto sym2 = affine_t::make_error_term();
+            ta_t x(
+              value_t(2.5),
+              typename ta_t::error_terms_t{{sym1, one}, {sym2, value_t(0.05)}},
+              T);
+            REQUIRE(x.error_terms().size() == 1);
+            REQUIRE(x.radius() == one);
         }
 
-        SECTION("Lump radii add in subtraction (no cancellation)") {
-            // With big_t, both x and y have non-zero lump radii after
-            // multiplication. Their difference has lump ≥ x.lump + y.lump
-            // because unsigned lumps always add.
-            ta_t x(one, two, big_t);
-            ta_t bump(one, value_t(1.01), big_t);
-            x *= bump;
-            ta_t y    = x; // copy, same lump radius value
-            ta_t diff = x - y;
-            REQUIRE(diff.lump_radius() >= x.lump_radius() + y.lump_radius());
-        }
-
-        SECTION("Signed lump can produce interval smaller than true range") {
-            // This test proved that the first implementation using signed lump
-            // violates the upper-bound guarantee. The root cause:
+        SECTION("Dropping is not conservative") {
+            // Because dropped terms are discarded rather than retained in a
+            // lump, a ThresholdedAffine range may be SMALLER than the
+            // corresponding Affine range — the upper-bound guarantee does not
+            // hold for the drop strategy.
             //
-            //   The copy constructor shares m_lump_term_ between a and its
-            //   copy b.  When an independent error is absorbed into the shared
-            //   lump of b (because it falls below the relative threshold), and
-            //   then a - b is computed, that absorbed error SUBTRACTS from the
-            //   shared lump contribution instead of ADDING to the radius.
+            // Trace (threshold = 10%):
+            //   a: center=2.5, {sym1: 1.0, sym2: 0.05}; sym2 dropped on
+            //      construction (0.05/1.05 ≈ 4.8% < 10%) → {sym1: 1.0}
+            //   b = a (copy), scaled by 0.9 → {sym1: 0.9}
+            //   c = [-0.03, 0.03]; on b += c the term 0.03/0.93 ≈ 3.2% < 10%
+            //      is dropped → b stays {sym1: 0.9}
+            //   diff = a - b = {sym1: 0.1} → radius = 0.1
             //
-            // Concrete trace:
-            //   a: center=2.5, {sym1: R=1.0, L_a: ds=0.05}
-            //      (sym2 with coeff ds was lumped on construction because
-            //       ds/(R+ds) = 0.048 < threshold=0.10)
-            //   b = a (copy, shares L_a), then scaled by alpha=0.9:
-            //      b: {sym1: 0.9, L_a: 0.045}
-            //   c = [-dn, dn] = [-0.03, 0.03] independent error; its single
-            //      term has relative contribution dn/0.975 ≈ 0.031 < 0.10 →
-            //      absorbed into L_a when b += c:
-            //      b: {sym1: 0.9, L_a: 0.075}
-            //   diff = a - b:
-            //      L_a coeff: 0.05 - 0.075 = -0.025 → |contrib| = 0.025
-            //      sym1 coeff: 1.0 - 0.9   =  0.100 → |contrib| = 0.100
-            //      ThresholdedAffine radius = 0.125
-            //
-            // Plain Affine (sym2 and ε_c tracked separately):
+            // Plain Affine (every term tracked):
             //   diff: {sym1: 0.10, sym2: 0.005, ε_c: -0.03} → radius = 0.135
             //
-            // The independent error dn=0.03 cancelled (net -0.025) instead of
-            // contributing +0.03, giving 0.125 < 0.135.  The true extremal
-            // value (sym2 and ε_c extremised in opposite directions) lies
-            // outside the ThresholdedAffine interval.
+            // 0.1 < 0.135: the discarded uncertainty shrinks the range.
 
-            const value_t R  = value_t(1.0);
-            const value_t ds = value_t(0.05); // lumped: 0.05/1.05 ≈ 4.8% < 10%
+            const value_t R     = value_t(1.0);
+            const value_t ds    = value_t(0.05); // dropped: 0.05/1.05 ≈ 4.8%
             const value_t alpha = value_t(0.9);
-            const value_t dn =
-              value_t(0.03); // lumped into b: 0.03/0.975 ≈ 3.1% < 10%
+            const value_t dn    = value_t(0.03); // dropped from b: ≈ 3.2%
             const threshold_t T{value_t(0.1)};
 
             auto sym1 = affine_t::make_error_term();
             auto sym2 = affine_t::make_error_term();
 
-            // ThresholdedAffine path: sym2 is lumped into L_a on construction.
+            // ThresholdedAffine path: sym2 is dropped on construction.
             ta_t a_ta(value_t(2.5),
                       typename ta_t::error_terms_t{{sym1, R}, {sym2, ds}}, T);
-            ta_t b_ta = a_ta;      // copy — shares lump symbol L_a
-            b_ta *= alpha;         // {sym1: 0.9, L_a: 0.045}
-            ta_t c_ta(-dn, dn, T); // single-term interval; not lumped within c
-            b_ta += c_ta;          // c's term absorbed into shared L_a → 0.075
+            ta_t b_ta = a_ta;
+            b_ta *= alpha;
+            ta_t c_ta(-dn, dn, T); // single-term interval; not dropped within c
+            b_ta += c_ta;          // c's term dropped on combine
             ta_t diff_ta = a_ta - b_ta;
 
-            // Plain Affine path: every term tracked individually, no lumping.
+            // Plain Affine path: every term tracked individually, no dropping.
             affine_t a_af(value_t(2.5), {{sym1, R}, {sym2, ds}});
             affine_t b_af = a_af * alpha;
             affine_t c_af(-dn, dn);
             affine_t diff_af = a_af - (b_af + c_af);
 
-            // After the fix: the unsigned lump never cancels, so the
-            // ThresholdedAffine radius is at least as large as the plain Affine
-            // radius (it may be larger because the lump from a and the lump
-            // from b both add, even though the sym2 part is correlated).
-            REQUIRE(diff_ta.radius() >= diff_af.radius());
-
-            // The ThresholdedAffine interval contains the correct range,
-            // satisfying the upper-bound guarantee.
-            REQUIRE(diff_ta.contains(diff_af.range()));
+            // Dropping discarded uncertainty, so the thresholded radius is the
+            // smaller of the two.
+            REQUIRE(diff_ta.radius() < diff_af.radius());
         }
     }
 }


### PR DESCRIPTION
As `ThresholdedAffine` (taffine) was implemented it contained a bug that allowed it to break bounds (would have been triggered by the "dropping is not conservative" test). At the same time, using an interval to collect the insignificant terms had an unintended side-effect: it caused the resulting uncertainty radii to more-or-less equal the uncertainty predicted by intervals (caused by cross-terms of the interval piece and the centers always being worst-case bounds).

This PR adjusts taffine so that it no longer "lumps" and instead "dumps" insignificant contributions. This also breaks conservativism, but with a conservative threshold the resulting uncertainty should still be an upper bound.

This is r2g.